### PR TITLE
Add govuk-content-schemas to Core and Custom teams

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -32,6 +32,7 @@ core-formats:
     - url-arbiter
     - content-register
     - panopticon
+    - govuk-content-schemas
 
   channel:
     "#core-formats"
@@ -54,6 +55,7 @@ custom:
     - content-store
     - courts-api
     - courts-frontend
+    - govuk-content-schemas
     - hmrc-manuals-api
     - imminence
     - licence-finder


### PR DESCRIPTION
This repo is relevant to all teams and is currently missing from the the Seal's morning announcement. This commit adds it to both teams' lists of repos.