### PR TITLE
Don't get angry when PRs are under two days old

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Just run `rspec` in the command line
 18th of June:
 - started Heroku scheduler and launched on core-formats team room!
 
+22nd of June
+- Ensure Angry seal doesn't get triggered at the weekend
+
 26th of June:
 - launched on finding-stuff team
 - investigated adding comments
@@ -102,14 +105,14 @@ Just run `rspec` in the command line
 17th of July
 - Angry Seal!
 
-To be done:
-- ensure Angry seal doesn't get triggered at the weekend
+21st of July
 - fix API stubbing
-- do not display [DO NOT MERGE] pull requests?
 
-Potential additional features:
-- angry seal post when PRs forgotten about
-- add age of pull requests
+22nd of July
+- Add age of pull requests
+
+To be done:
+- do not display [DO NOT MERGE] pull requests?
 
 How to find out list of alphagov repos modified within the last year:
 In irb, from the folder of the project, run:

--- a/config/envato.yml
+++ b/config/envato.yml
@@ -1,10 +1,13 @@
 envato-market:
   members: []
   repos:
+    - docs
+    - envato.com
     - marketplace
     - marketplace-puppet
-    - webuild.envato.com
     - new-coding-test
+    - our-boxen
+    - webuild.envato.com
 
   channel: '#marketplacedev'
 

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -67,7 +67,7 @@ class MessageBuilder
     pr = pull_requests[pull_request]
     days = age_in_days(pr)
     <<-EOF.gsub(/^\s+/, '')
-    #{index}\) *#{pr["repo"]}* | #{pr["author"]} (#{days} #{days_plural(days)} ago)
+    #{index}\) *#{pr["repo"]}* | #{pr["author"]} (last updated #{days} #{days_plural(days)} ago)
     <#{pr["link"]}|#{pr["title"]}> - #{pr["comments_count"]}#{comments(pull_request)}
     EOF
   end

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -30,8 +30,7 @@ class MessageBuilder
   end
 
   def rotten?(pull_request)
-    return true if pull_request["updated"] + 2 < Date.today
-    false
+    age_in_days(pull_request) > 2
   end
 
   private

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -34,13 +34,8 @@ class MessageBuilder
   end
 
   def list_pull_requests
-  @report = "Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n"
-    n = 0
-    @pull_requests.each_key do |pull_request|
-      n += 1
-      @report = @report + present(pull_request, n)
-    end
-  @report = @report + "\nMerry reviewing!"
+    msg = @pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
+    "Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n#{msg.join}\nMerry reviewing!"
   end
 
   def no_pull_requests
@@ -90,11 +85,10 @@ class MessageBuilder
   end
 
   def informative
-   if @pull_requests == {}
+   if @pull_requests.empty?
       no_pull_requests
     else
       list_pull_requests
-      @report
     end
   end
 

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -18,17 +18,17 @@ class MessageBuilder
     end
   end
 
-  def check_old_pull_requests
-    @old_pull_requests = @pull_requests.reject { |title, pr| !rotten?(pr) }
-    msg = @old_pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
-    @alert = "AAAAAAARGH! #{these} #{pr_plural} not been updated in over 2 days.\n\n#{msg.join}\n\n Remember each time you time you forget to review your pull requests, a baby seal dies."
-  end
-
   def rotten?(pull_request)
     age_in_days(pull_request) > 2
   end
 
   private
+
+  def check_old_pull_requests
+    @old_pull_requests = @pull_requests.reject { |title, pr| !rotten?(pr) }
+    msg = @old_pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
+    @alert = "AAAAAAARGH! #{these} #{pr_plural} not been updated in over 2 days.\n\n#{msg.join}\n\n Remember each time you time you forget to review your pull requests, a baby seal dies."
+  end
 
   def list_pull_requests
   @report = "Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n"

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -21,7 +21,7 @@ class MessageBuilder
   def check_old_pull_requests
     @old_pull_requests = @pull_requests.reject { |title, pr| !rotten?(pr) }
     msg = @old_pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
-    @alert = "AAAAAAARGH! #{these} #{pr_plural} not been updated in over 2 days.\n\n" + msg.join + "\n\n Remember each time you time you forget to review your pull requests, a baby seal dies."
+    @alert = "AAAAAAARGH! #{these} #{pr_plural} not been updated in over 2 days.\n\n#{msg.join}\n\n Remember each time you time you forget to review your pull requests, a baby seal dies."
   end
 
   def rotten?(pull_request)

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -19,12 +19,11 @@ class MessageBuilder
   end
 
   def check_old_pull_requests
-    @old_pull_requests = []
+    @old_pull_requests = @pull_requests.reject { |title, pr| !rotten?(pr) }
     n = 0
-    @pull_requests.each do |title, pull_request|
+    @old_pull_requests.each do |title, pull_request|
       n += 1
       @alert = @alert + present(title, n)
-      @old_pull_requests << pull_request if rotten?(pull_request)
     end
     @alert = "AAAAAAARGH! #{these} #{pr_plural} not been updated in over 2 days.\n\n" + @alert + "\n\n Remember each time you time you forget to review your pull requests, a baby seal dies."
   end

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -67,8 +67,9 @@ class MessageBuilder
 
   def present(pull_request, index)
     pr = pull_requests[pull_request]
+    days = (Date.today - pr['updated']).to_i
     <<-EOF.gsub(/^\s+/, '')
-    #{index}\) *#{pr["repo"]}* | #{pr["author"]}
+    #{index}\) *#{pr["repo"]}* | #{pr["author"]} (#{days} days ago)
     <#{pr["link"]}|#{pr["title"]}> - #{pr["comments_count"]}#{comments(pull_request)}
     EOF
   end

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -20,12 +20,8 @@ class MessageBuilder
 
   def check_old_pull_requests
     @old_pull_requests = @pull_requests.reject { |title, pr| !rotten?(pr) }
-    n = 0
-    @old_pull_requests.each do |title, pull_request|
-      n += 1
-      @alert = @alert + present(title, n)
-    end
-    @alert = "AAAAAAARGH! #{these} #{pr_plural} not been updated in over 2 days.\n\n" + @alert + "\n\n Remember each time you time you forget to review your pull requests, a baby seal dies."
+    msg = @old_pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
+    @alert = "AAAAAAARGH! #{these} #{pr_plural} not been updated in over 2 days.\n\n" + msg.join + "\n\n Remember each time you time you forget to review your pull requests, a baby seal dies."
   end
 
   def rotten?(pull_request)

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -68,13 +68,21 @@ class MessageBuilder
     pr = pull_requests[pull_request]
     days = age_in_days(pr)
     <<-EOF.gsub(/^\s+/, '')
-    #{index}\) *#{pr["repo"]}* | #{pr["author"]} (#{days} days ago)
+    #{index}\) *#{pr["repo"]}* | #{pr["author"]} (#{days} #{days_plural(days)} ago)
     <#{pr["link"]}|#{pr["title"]}> - #{pr["comments_count"]}#{comments(pull_request)}
     EOF
   end
 
   def age_in_days(pull_request)
     (Date.today - pull_request['updated']).to_i
+  end
+
+  def days_plural(days)
+    if days == 1
+      'day'
+    else
+      'days'
+    end
   end
 
   def informative

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -85,7 +85,7 @@ class MessageBuilder
   end
 
   def informative
-   if @pull_requests.empty?
+    if @pull_requests.empty?
       no_pull_requests
     else
       list_pull_requests
@@ -99,5 +99,4 @@ class MessageBuilder
       bark_about_old_pull_requests
     end
   end
-
 end

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -67,11 +67,15 @@ class MessageBuilder
 
   def present(pull_request, index)
     pr = pull_requests[pull_request]
-    days = (Date.today - pr['updated']).to_i
+    days = age_in_days(pr)
     <<-EOF.gsub(/^\s+/, '')
     #{index}\) *#{pr["repo"]}* | #{pr["author"]} (#{days} days ago)
     <#{pr["link"]}|#{pr["title"]}> - #{pr["comments_count"]}#{comments(pull_request)}
     EOF
+  end
+
+  def age_in_days(pull_request)
+    (Date.today - pull_request['updated']).to_i
   end
 
   def informative

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -8,6 +8,8 @@ describe MessageBuilder do
   let(:no_pull_requests) { {} }
   let(:old_pull_requests)   { { '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host' => { 'title' => '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host', 'link' => 'https://github.com/alphagov/whitehall/pull/2266', 'author' => 'mattbostock', 'repo' => 'whitehall', 'comments_count' => '1', 'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)') }, 'Remove all Import-related code' => { 'title' => 'Remove all Import-related code', 'link' => 'https://github.com/alphagov/whitehall/pull/2248', 'author' => 'tekin', 'repo' => 'whitehall', 'comments_count' => '5', 'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)') } } }
 
+  before { Timecop.freeze(Time.local(2015, 07, 18)) }
+
   context 'informative' do
     let(:mood) { 'informative' }
 
@@ -15,7 +17,7 @@ describe MessageBuilder do
       let(:pull_requests) { old_pull_requests }
 
       it 'builds message' do
-        expect(message_builder.build).to eq("Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | mattbostock\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
+        expect(message_builder.build).to eq("Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin (1 days ago)\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
       end
     end
 
@@ -35,7 +37,7 @@ describe MessageBuilder do
       let(:pull_requests) { old_pull_requests }
 
       it 'builds message' do
-        expect(message_builder.build).to eq("AAAAAAARGH! These pull requests have not been updated in over 2 days.\n\n1) *whitehall* | mattbostock\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
+        expect(message_builder.build).to eq("AAAAAAARGH! These pull requests have not been updated in over 2 days.\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin (1 days ago)\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
       end
     end
 

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -9,6 +9,7 @@ describe MessageBuilder do
   let(:old_pull_requests)   { { '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host' => { 'title' => '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host', 'link' => 'https://github.com/alphagov/whitehall/pull/2266', 'author' => 'mattbostock', 'repo' => 'whitehall', 'comments_count' => '1', 'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)') }, 'Remove all Import-related code' => { 'title' => 'Remove all Import-related code', 'link' => 'https://github.com/alphagov/whitehall/pull/2248', 'author' => 'tekin', 'repo' => 'whitehall', 'comments_count' => '5', 'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)') } } }
 
   before { Timecop.freeze(Time.local(2015, 07, 18)) }
+  after { Timecop.return }
 
   context 'informative' do
     let(:mood) { 'informative' }
@@ -63,10 +64,6 @@ describe MessageBuilder do
 
         it 'is rotten' do
           expect(message_builder).to be_rotten(pull_request)
-        end
-
-        after do
-          Timecop.return
         end
       end
 

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -18,7 +18,7 @@ describe MessageBuilder do
       let(:pull_requests) { old_pull_requests }
 
       it 'builds message' do
-        expect(message_builder.build).to eq("Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin (1 day ago)\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
+        expect(message_builder.build).to eq("Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | mattbostock (last updated 5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin (last updated 1 day ago)\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
       end
     end
 
@@ -38,7 +38,7 @@ describe MessageBuilder do
       let(:pull_requests) { old_pull_requests }
 
       it 'builds message' do
-        expect(message_builder.build).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
+        expect(message_builder.build).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock (last updated 5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
       end
     end
 

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -38,7 +38,7 @@ describe MessageBuilder do
       let(:pull_requests) { old_pull_requests }
 
       it 'builds message' do
-        expect(message_builder.build).to eq("AAAAAAARGH! These pull requests have not been updated in over 2 days.\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
+        expect(message_builder.build).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
       end
     end
 

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -38,7 +38,7 @@ describe MessageBuilder do
       let(:pull_requests) { old_pull_requests }
 
       it 'builds message' do
-        expect(message_builder.build).to eq("AAAAAAARGH! These pull requests have not been updated in over 2 days.\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin (1 day ago)\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
+        expect(message_builder.build).to eq("AAAAAAARGH! These pull requests have not been updated in over 2 days.\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
       end
     end
 

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -17,7 +17,7 @@ describe MessageBuilder do
       let(:pull_requests) { old_pull_requests }
 
       it 'builds message' do
-        expect(message_builder.build).to eq("Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin (1 days ago)\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
+        expect(message_builder.build).to eq("Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin (1 day ago)\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
       end
     end
 
@@ -37,7 +37,7 @@ describe MessageBuilder do
       let(:pull_requests) { old_pull_requests }
 
       it 'builds message' do
-        expect(message_builder.build).to eq("AAAAAAARGH! These pull requests have not been updated in over 2 days.\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin (1 days ago)\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
+        expect(message_builder.build).to eq("AAAAAAARGH! These pull requests have not been updated in over 2 days.\n\n1) *whitehall* | mattbostock (5 days ago)\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin (1 day ago)\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
       end
     end
 


### PR DESCRIPTION
# Context

After I deployed https://github.com/binaryberry/seal/pull/8 , one of my colleagues pointed out that the angry seal was complaining about a PR that he'd written that day.

# Changes

- Added the age to the PR presentation
- Filtered out PRs younger than 2 days old from angry seal messages
- Performed some pipeline refactoring
- Fixed a couple of display bugs