### PR TITLE
Do not display [DO NOT MERGE] / WIP pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,12 @@ Just run `rspec` in the command line
 22nd of July
 - Add age of pull requests
 
-To be done:
-- do not display [DO NOT MERGE] pull requests?
+24th of July
+- Optionally display labels for a pull request, if they exist (`use_labels` config option)
+- Optionally hide pull requests with certain labels (`exclude_labels` config
+  list)
+- Optionally hid pull requests with certain phrases in the title
+  (`exclude_titles` config list)
 
 How to find out list of alphagov repos modified within the last year:
 In irb, from the folder of the project, run:

--- a/config/envato.yml
+++ b/config/envato.yml
@@ -1,4 +1,5 @@
 envato-market:
+  channel: '#marketplacedev'
   members: []
   repos:
     - docs
@@ -8,6 +9,6 @@ envato-market:
     - new-coding-test
     - our-boxen
     - webuild.envato.com
+  use_labels: true
 
-  channel: '#marketplacedev'
 

--- a/config/envato.yml
+++ b/config/envato.yml
@@ -10,5 +10,7 @@ envato-market:
     - our-boxen
     - webuild.envato.com
   use_labels: true
+  exclude_labels:
+    - wip
 
 

--- a/config/envato.yml
+++ b/config/envato.yml
@@ -12,5 +12,6 @@ envato-market:
   use_labels: true
   exclude_labels:
     - wip
+    - WIP
 
 

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -20,17 +20,17 @@ class GithubFetcher
   def list_pull_requests
     @repos.each do |repo|
       response = @github.pull_requests("#{ORGANISATION}/#{repo}", state: "open")
-      response.reject { |pr| hidden_labels(pr, repo) }.each do |pull_request|
-        if pull_request_valid?(pull_request)
-          @pull_requests[pull_request.title] = {}
-          @pull_requests[pull_request.title]["title"] = pull_request.title
-          @pull_requests[pull_request.title]["link"] = pull_request.html_url
-          @pull_requests[pull_request.title]["author"] = pull_request.user.login
-          @pull_requests[pull_request.title]["repo"] = repo
-          @pull_requests[pull_request.title]["comments_count"] = count_comments(pull_request, repo)
-          @pull_requests[pull_request.title]["updated"] = Date.parse(pull_request.updated_at.to_s)
-          @pull_requests[pull_request.title]['labels'] = labels(pull_request, repo)
-        end
+      response.reject { |pr| hidden_labels(pr, repo) }
+        .select { |pr| pull_request_valid?(pr) }
+        .each do |pull_request|
+        @pull_requests[pull_request.title] = {}
+        @pull_requests[pull_request.title]["title"] = pull_request.title
+        @pull_requests[pull_request.title]["link"] = pull_request.html_url
+        @pull_requests[pull_request.title]["author"] = pull_request.user.login
+        @pull_requests[pull_request.title]["repo"] = repo
+        @pull_requests[pull_request.title]["comments_count"] = count_comments(pull_request, repo)
+        @pull_requests[pull_request.title]["updated"] = Date.parse(pull_request.updated_at.to_s)
+        @pull_requests[pull_request.title]['labels'] = labels(pull_request, repo)
       end
     end
     @pull_requests

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -27,6 +27,7 @@ class GithubFetcher
           @pull_requests[pull_request.title]["repo"] = repo
           @pull_requests[pull_request.title]["comments_count"] = count_comments(pull_request, repo)
           @pull_requests[pull_request.title]["updated"] = Date.parse(pull_request.updated_at.to_s)
+          @pull_requests[pull_request.title]['labels'] = labels(pull_request, repo)
         end
       end
     end
@@ -65,4 +66,7 @@ class GithubFetcher
     @total_comments = (review_comments + comments).to_s
   end
 
+  def labels(pull_request, repo)
+    @github.labels_for_issue("#{ORGANISATION}/#{repo}", pull_request.number)
+  end
 end

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -3,7 +3,7 @@ require 'octokit'
 class GithubFetcher
   ORGANISATION ||= ENV['SEAL_ORGANISATION']
 
-  attr_accessor :people, :repos, :pull_requests
+  attr_accessor :people, :repos
 
   def initialize(team_members_accounts, team_repos, use_labels, exclude_labels)
     @github = Octokit::Client.new(:access_token => ENV['GITHUB_TOKEN'])
@@ -35,20 +35,6 @@ class GithubFetcher
       end
     end
     @pull_requests
-  end
-
-  def old_pull_requests
-    @repos.each do |repo|
-      response = @github.pull_requests("#{ORGANISATION}/#{repo}", state: "open")
-      response.each do |pull_request|
-        if person_subscribed?(pull_request)
-          comments = @github.pull_request_comments("#{ORGANISATION}/#{repo}", pull_request.number) #this returns an empty array, not sure why
-          comments.each do |comment|
-            comment.updated_at
-          end
-        end
-      end
-    end
   end
 
   private

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -23,14 +23,15 @@ class GithubFetcher
       response.reject { |pr| hidden_labels(pr, repo) }
         .select { |pr| pull_request_valid?(pr) }
         .each do |pull_request|
-        @pull_requests[pull_request.title] = {}
-        @pull_requests[pull_request.title]["title"] = pull_request.title
-        @pull_requests[pull_request.title]["link"] = pull_request.html_url
-        @pull_requests[pull_request.title]["author"] = pull_request.user.login
-        @pull_requests[pull_request.title]["repo"] = repo
-        @pull_requests[pull_request.title]["comments_count"] = count_comments(pull_request, repo)
-        @pull_requests[pull_request.title]["updated"] = Date.parse(pull_request.updated_at.to_s)
-        @pull_requests[pull_request.title]['labels'] = labels(pull_request, repo)
+        @pull_requests[pull_request.title] = {}.tap do |pr|
+          pr['title'] = pull_request.title
+          pr['link'] = pull_request.html_url
+          pr['author'] = pull_request.user.login
+          pr['repo'] = repo
+          pr['comments_count'] = count_comments(pull_request, repo)
+          pr['updated'] = Date.parse(pull_request.updated_at.to_s)
+          pr['labels'] = labels(pull_request, repo)
+        end
       end
     end
     @pull_requests

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -5,7 +5,7 @@ class GithubFetcher
 
   attr_accessor :people, :repos, :pull_requests
 
-  def initialize(team_members_accounts, team_repos)
+  def initialize(team_members_accounts, team_repos, use_labels)
     @github = Octokit::Client.new(:access_token => ENV['GITHUB_TOKEN'])
     @github.user.login
     Octokit.auto_paginate = true
@@ -13,6 +13,7 @@ class GithubFetcher
     @repos = team_repos.sort!
     @pull_requests = {}
     @old_pull_requests = []
+    @use_labels = use_labels
   end
 
   def list_pull_requests
@@ -50,6 +51,8 @@ class GithubFetcher
 
   private
 
+  attr_reader :use_labels
+
   def pull_request_valid?(pull_request)
     if people.empty?
       true
@@ -67,6 +70,7 @@ class GithubFetcher
   end
 
   def labels(pull_request, repo)
+    return [] unless use_labels
     @github.labels_for_issue("#{ORGANISATION}/#{repo}", pull_request.number)
   end
 end

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -21,10 +21,7 @@ class GithubFetcher
   def list_pull_requests
     @repos.each do |repo|
       response = @github.pull_requests("#{ORGANISATION}/#{repo}", state: "open")
-      response.reject { |pr| hidden_labels(pr, repo) }
-        .reject { |pr| hidden_titles(pr.title) }
-        .select { |pr| person_subscribed?(pr) }
-        .each do |pull_request|
+      response.reject { |pr| hidden?(pr, repo) }.each do |pull_request|
         @pull_requests[pull_request.title] = {}.tap do |pr|
           pr['title'] = pull_request.title
           pr['link'] = pull_request.html_url
@@ -56,6 +53,10 @@ class GithubFetcher
   def labels(pull_request, repo)
     return [] unless use_labels
     @github.labels_for_issue("#{ORGANISATION}/#{repo}", pull_request.number)
+  end
+
+  def hidden?(pull_request, repo)
+    hidden_labels(pull_request, repo) || hidden_titles(pull_request.title) || !person_subscribed?(pull_request)
   end
 
   def hidden_labels(pull_request, repo)

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -25,7 +25,7 @@ class MessageBuilder
   private
 
   def old_pull_requests
-    @old_pull_requests ||= @pull_requests.reject { |title, pr| !rotten?(pr) }
+    @old_pull_requests ||= @pull_requests.reject { |_title, pr| !rotten?(pr) }
   end
 
   def bark_about_old_pull_requests

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -25,7 +25,7 @@ class MessageBuilder
   private
 
   def old_pull_requests
-    @old_pull_requests ||= @pull_requests.reject { |_title, pr| !rotten?(pr) }
+    @old_pull_requests ||= @pull_requests.select { |_title, pr| rotten?(pr) }
   end
 
   def bark_about_old_pull_requests

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -68,7 +68,7 @@ class MessageBuilder
     days = age_in_days(pr)
     <<-EOF.gsub(/^\s+/, '')
     #{index}\) *#{pr["repo"]}* | #{pr["author"]} | updated #{days_plural(days)}
-    <#{pr["link"]}|#{pr["title"]}> - #{pr["comments_count"]}#{comments(pull_request)}
+    #{labels(pr)} <#{pr["link"]}|#{pr["title"]}> - #{pr["comments_count"]}#{comments(pull_request)}
     EOF
   end
 
@@ -101,5 +101,11 @@ class MessageBuilder
     else
       bark_about_old_pull_requests
     end
+  end
+
+  def labels(pull_request)
+    pull_request['labels']
+      .map { |label| "[#{label['name']}]" }
+      .join(' ')
   end
 end

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -31,7 +31,7 @@ class Seal
   end
 
   def pull_requests
-    git = GithubFetcher.new(config['members'], config['repos'], config['use_labels'])
+    git = GithubFetcher.new(config['members'], config['repos'], config['use_labels'], config['exclude_labels'])
     git.list_pull_requests
   end
 end

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -31,7 +31,12 @@ class Seal
   end
 
   def pull_requests
-    git = GithubFetcher.new(config['members'], config['repos'], config['use_labels'], config['exclude_labels'])
+    git = GithubFetcher.new(config['members'],
+                            config['repos'],
+                            config['use_labels'],
+                            config['exclude_labels'],
+                            config['exclude_titles']
+                           )
     git.list_pull_requests
   end
 end

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -31,7 +31,7 @@ class Seal
   end
 
   def pull_requests
-    git = GithubFetcher.new(config['members'], config['repos'])
+    git = GithubFetcher.new(config['members'], config['repos'], config['use_labels'])
     git.list_pull_requests
   end
 end

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -31,6 +31,21 @@ describe 'GithubFetcher' do
             )
     end
 
+    let(:labels_for_2248) do
+      [
+        {
+          :url => 'https://api.github.com/repos/alphagov/whitehall/labels/blocked',
+          :name => 'blocked',
+          :color => 'e11d21'
+        },
+        {
+          :url => 'https://api.github.com/repos/alphagov/whitehall/labels/wip',
+          :name => 'wip',
+          :color => 'fbca04'
+        }
+      ]
+    end
+
     before do
       REPO_NAME = "#{GithubFetcher::ORGANISATION}/whitehall"
       expect(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
@@ -38,6 +53,8 @@ describe 'GithubFetcher' do
       expect(fake_octokit_client).to receive(:pull_requests).and_return([pull_2266, pull_2248])
       expect(fake_octokit_client).to receive(:pull_request).at_least(:once).with(REPO_NAME, 2248).and_return(pull_2248)
       expect(fake_octokit_client).to receive(:pull_request).at_least(:once).with(REPO_NAME, 2266).and_return(pull_2266)
+      expect(fake_octokit_client).to receive(:labels_for_issue).at_least(:once).with(REPO_NAME, 2248).and_return(labels_for_2248)
+      expect(fake_octokit_client).to receive(:labels_for_issue).at_least(:once).with(REPO_NAME, 2266).and_return([])
     end
 
     it "displays open pull requests open on the team's repos by a team member" do
@@ -49,7 +66,8 @@ describe 'GithubFetcher' do
           'author' => 'mattbostock',
           'repo' => 'whitehall',
           'comments_count' => '1',
-          'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)')
+          'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)'),
+          'labels' => []
         },
 
         'Remove all Import-related code' =>
@@ -59,7 +77,8 @@ describe 'GithubFetcher' do
           'author' => 'tekin',
           'repo' => 'whitehall',
           'comments_count' => '5',
-          'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)')
+          'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)'),
+          'labels' => labels_for_2248
         }
       }
 

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -2,87 +2,109 @@ require 'spec_helper'
 require './lib/github_fetcher'
 
 describe 'GithubFetcher' do
-  context '#list_pull_requests' do
-    subject(:github_fetcher) { GithubFetcher.new(team_members_accounts, team_repos) }
+  shared_examples_for 'fetching from GitHub' do
+    let(:repo_name) { "#{GithubFetcher::ORGANISATION}/whitehall" }
 
-    let(:fake_octokit_client) { double(Octokit::Client) }
-    let(:team_members_accounts) { %w(binaryberry boffbowsh jackscotti tekin elliotcm tommyp mattbostock) }
-    let(:team_repos) { %w(whitehall) }
-    let(:pull_2266) do
-      double(Sawyer::Resource,
-             user: double(Sawyer::Resource, login: 'mattbostock'),
-             title: '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
-             html_url: 'https://github.com/alphagov/whitehall/pull/2266',
-             number: 2266,
-             review_comments: 1,
-             comments: 0,
-             updated_at: '2015-07-13 01:00:44 UTC'
-            )
-    end
-    let(:pull_2248) do
-      double(Sawyer::Resource,
-             user: double(Sawyer::Resource, login: 'tekin'),
-             title: 'Remove all Import-related code',
-             html_url: 'https://github.com/alphagov/whitehall/pull/2248',
-             number: 2248,
-             review_comments: 1,
-             comments: 4,
-             updated_at: '2015-07-17 01:00:44 UTC'
-            )
-    end
+    describe '#list_pull_requests' do
+      subject(:github_fetcher) { GithubFetcher.new(team_members_accounts, team_repos, use_labels) }
 
-    let(:labels_for_2248) do
-      [
+      let(:fake_octokit_client) { double(Octokit::Client) }
+      let(:team_members_accounts) { %w(binaryberry boffbowsh jackscotti tekin elliotcm tommyp mattbostock) }
+      let(:team_repos) { %w(whitehall) }
+      let(:pull_2266) do
+        double(Sawyer::Resource,
+               user: double(Sawyer::Resource, login: 'mattbostock'),
+               title: '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
+               html_url: 'https://github.com/alphagov/whitehall/pull/2266',
+               number: 2266,
+               review_comments: 1,
+               comments: 0,
+               updated_at: '2015-07-13 01:00:44 UTC'
+              )
+      end
+      let(:pull_2248) do
+        double(Sawyer::Resource,
+               user: double(Sawyer::Resource, login: 'tekin'),
+               title: 'Remove all Import-related code',
+               html_url: 'https://github.com/alphagov/whitehall/pull/2248',
+               number: 2248,
+               review_comments: 1,
+               comments: 4,
+               updated_at: '2015-07-17 01:00:44 UTC'
+              )
+      end
+
+      let(:labels_for_2248) do
+        [
+          {
+            :url => 'https://api.github.com/repos/alphagov/whitehall/labels/blocked',
+            :name => 'blocked',
+            :color => 'e11d21'
+          },
+          {
+            :url => 'https://api.github.com/repos/alphagov/whitehall/labels/wip',
+            :name => 'wip',
+            :color => 'fbca04'
+          }
+        ]
+      end
+
+      let(:expected_open_prs) do
         {
-          :url => 'https://api.github.com/repos/alphagov/whitehall/labels/blocked',
-          :name => 'blocked',
-          :color => 'e11d21'
-        },
-        {
-          :url => 'https://api.github.com/repos/alphagov/whitehall/labels/wip',
-          :name => 'wip',
-          :color => 'fbca04'
+          '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host' =>
+            {
+              'title' => '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
+              'link' => 'https://github.com/alphagov/whitehall/pull/2266',
+              'author' => 'mattbostock',
+              'repo' => 'whitehall',
+              'comments_count' => '1',
+              'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)'),
+              'labels' => []
+            },
+
+          'Remove all Import-related code' =>
+            {
+              'title' => 'Remove all Import-related code',
+              'link' => 'https://github.com/alphagov/whitehall/pull/2248',
+              'author' => 'tekin',
+              'repo' => 'whitehall',
+              'comments_count' => '5',
+              'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)'),
+              'labels' => []
+            }
         }
-      ]
+      end
+
+      before do
+        expect(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
+        expect(fake_octokit_client).to receive_message_chain('user.login')
+        expect(fake_octokit_client).to receive(:pull_requests).and_return([pull_2266, pull_2248])
+        expect(fake_octokit_client).to receive(:pull_request).at_least(:once).with(repo_name, 2248).and_return(pull_2248)
+        expect(fake_octokit_client).to receive(:pull_request).at_least(:once).with(repo_name, 2266).and_return(pull_2266)
+      end
+
+      it "displays open pull requests open on the team's repos by a team member" do
+        expect(github_fetcher.list_pull_requests).to match expected_open_prs
+      end
     end
+  end
+
+  context 'labels turned on' do
+    let(:use_labels) { true }
 
     before do
-      REPO_NAME = "#{GithubFetcher::ORGANISATION}/whitehall"
-      expect(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
-      expect(fake_octokit_client).to receive_message_chain('user.login')
-      expect(fake_octokit_client).to receive(:pull_requests).and_return([pull_2266, pull_2248])
-      expect(fake_octokit_client).to receive(:pull_request).at_least(:once).with(REPO_NAME, 2248).and_return(pull_2248)
-      expect(fake_octokit_client).to receive(:pull_request).at_least(:once).with(REPO_NAME, 2266).and_return(pull_2266)
-      expect(fake_octokit_client).to receive(:labels_for_issue).at_least(:once).with(REPO_NAME, 2248).and_return(labels_for_2248)
-      expect(fake_octokit_client).to receive(:labels_for_issue).at_least(:once).with(REPO_NAME, 2266).and_return([])
+      expect(fake_octokit_client).to receive(:labels_for_issue).at_least(:once).with(repo_name, 2248).and_return(labels_for_2248)
+      expect(fake_octokit_client).to receive(:labels_for_issue).at_least(:once).with(repo_name, 2266).and_return([])
+
+      expected_open_prs['Remove all Import-related code']['labels'] = labels_for_2248
     end
 
-    it "displays open pull requests open on the team's repos by a team member" do
-      OPEN_PRS = {
-        '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host' =>
-        {
-          'title' => '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
-          'link' => 'https://github.com/alphagov/whitehall/pull/2266',
-          'author' => 'mattbostock',
-          'repo' => 'whitehall',
-          'comments_count' => '1',
-          'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)'),
-          'labels' => []
-        },
+    it_behaves_like 'fetching from GitHub'
+  end
 
-        'Remove all Import-related code' =>
-        {
-          'title' => 'Remove all Import-related code',
-          'link' => 'https://github.com/alphagov/whitehall/pull/2248',
-          'author' => 'tekin',
-          'repo' => 'whitehall',
-          'comments_count' => '5',
-          'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)'),
-          'labels' => labels_for_2248
-        }
-      }
+  context 'labels turned off' do
+    let(:use_labels) { false }
 
-      expect(github_fetcher.list_pull_requests).to match OPEN_PRS
-    end
+    it_behaves_like 'fetching from GitHub'
   end
 end

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -2,87 +2,85 @@ require 'spec_helper'
 require './lib/github_fetcher'
 
 describe 'GithubFetcher' do
-  shared_examples_for 'fetching from GitHub' do
-    let(:repo_name) { "#{GithubFetcher::ORGANISATION}/whitehall" }
+  subject(:github_fetcher) { GithubFetcher.new(team_members_accounts, team_repos, use_labels, exclude_labels) }
+  let(:fake_octokit_client) { double(Octokit::Client) }
+  let(:repo_name) { "#{GithubFetcher::ORGANISATION}/whitehall" }
+  let(:blocked_and_wip) do
+    [
+      {
+        'url' => 'https://api.github.com/repos/alphagov/whitehall/labels/blocked',
+        'name' => 'blocked',
+        'color' => 'e11d21'
+      },
+      {
+        'url' => 'https://api.github.com/repos/alphagov/whitehall/labels/wip',
+        'name' => 'wip',
+        'color' => 'fbca04'
+      }
+    ]
+  end
 
-    describe '#list_pull_requests' do
-      subject(:github_fetcher) { GithubFetcher.new(team_members_accounts, team_repos, use_labels) }
-
-      let(:fake_octokit_client) { double(Octokit::Client) }
-      let(:team_members_accounts) { %w(binaryberry boffbowsh jackscotti tekin elliotcm tommyp mattbostock) }
-      let(:team_repos) { %w(whitehall) }
-      let(:pull_2266) do
-        double(Sawyer::Resource,
-               user: double(Sawyer::Resource, login: 'mattbostock'),
-               title: '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
-               html_url: 'https://github.com/alphagov/whitehall/pull/2266',
-               number: 2266,
-               review_comments: 1,
-               comments: 0,
-               updated_at: '2015-07-13 01:00:44 UTC'
-              )
-      end
-      let(:pull_2248) do
-        double(Sawyer::Resource,
-               user: double(Sawyer::Resource, login: 'tekin'),
-               title: 'Remove all Import-related code',
-               html_url: 'https://github.com/alphagov/whitehall/pull/2248',
-               number: 2248,
-               review_comments: 1,
-               comments: 4,
-               updated_at: '2015-07-17 01:00:44 UTC'
-              )
-      end
-
-      let(:labels_for_2248) do
-        [
-          {
-            :url => 'https://api.github.com/repos/alphagov/whitehall/labels/blocked',
-            :name => 'blocked',
-            :color => 'e11d21'
-          },
-          {
-            :url => 'https://api.github.com/repos/alphagov/whitehall/labels/wip',
-            :name => 'wip',
-            :color => 'fbca04'
-          }
-        ]
-      end
-
-      let(:expected_open_prs) do
+  let(:expected_open_prs) do
+    {
+      '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host' =>
         {
-          '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host' =>
-            {
-              'title' => '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
-              'link' => 'https://github.com/alphagov/whitehall/pull/2266',
-              'author' => 'mattbostock',
-              'repo' => 'whitehall',
-              'comments_count' => '1',
-              'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)'),
-              'labels' => []
-            },
+          'title' => '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
+          'link' => 'https://github.com/alphagov/whitehall/pull/2266',
+          'author' => 'mattbostock',
+          'repo' => 'whitehall',
+          'comments_count' => '1',
+          'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)'),
+          'labels' => []
+        },
 
-          'Remove all Import-related code' =>
-            {
-              'title' => 'Remove all Import-related code',
-              'link' => 'https://github.com/alphagov/whitehall/pull/2248',
-              'author' => 'tekin',
-              'repo' => 'whitehall',
-              'comments_count' => '5',
-              'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)'),
-              'labels' => []
-            }
+      'Remove all Import-related code' =>
+        {
+          'title' => 'Remove all Import-related code',
+          'link' => 'https://github.com/alphagov/whitehall/pull/2248',
+          'author' => 'tekin',
+          'repo' => 'whitehall',
+          'comments_count' => '5',
+          'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)'),
+          'labels' => []
         }
-      end
+    }
+  end
+  let(:exclude_labels) { nil }
+  let(:team_members_accounts) { %w(binaryberry boffbowsh jackscotti tekin elliotcm tommyp mattbostock) }
+  let(:team_repos) { %w(whitehall) }
+  let(:pull_2266) do
+    double(Sawyer::Resource,
+           user: double(Sawyer::Resource, login: 'mattbostock'),
+           title: '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
+           html_url: 'https://github.com/alphagov/whitehall/pull/2266',
+           number: 2266,
+           review_comments: 1,
+           comments: 0,
+           updated_at: '2015-07-13 01:00:44 UTC'
+          )
+  end
+  let(:pull_2248) do
+    double(Sawyer::Resource,
+           user: double(Sawyer::Resource, login: 'tekin'),
+           title: 'Remove all Import-related code',
+           html_url: 'https://github.com/alphagov/whitehall/pull/2248',
+           number: 2248,
+           review_comments: 1,
+           comments: 4,
+           updated_at: '2015-07-17 01:00:44 UTC'
+          )
+  end
 
-      before do
-        expect(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
-        expect(fake_octokit_client).to receive_message_chain('user.login')
-        expect(fake_octokit_client).to receive(:pull_requests).and_return([pull_2266, pull_2248])
-        expect(fake_octokit_client).to receive(:pull_request).at_least(:once).with(repo_name, 2248).and_return(pull_2248)
-        expect(fake_octokit_client).to receive(:pull_request).at_least(:once).with(repo_name, 2266).and_return(pull_2266)
-      end
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
+    allow(fake_octokit_client).to receive_message_chain('user.login')
+    allow(fake_octokit_client).to receive(:pull_requests).and_return([pull_2266, pull_2248])
+    allow(fake_octokit_client).to receive(:pull_request).at_least(:once).with(repo_name, 2248).and_return(pull_2248)
+    allow(fake_octokit_client).to receive(:pull_request).at_least(:once).with(repo_name, 2266).and_return(pull_2266)
+  end
 
+  shared_examples_for 'fetching from GitHub' do
+    describe '#list_pull_requests' do
       it "displays open pull requests open on the team's repos by a team member" do
         expect(github_fetcher.list_pull_requests).to match expected_open_prs
       end
@@ -93,13 +91,30 @@ describe 'GithubFetcher' do
     let(:use_labels) { true }
 
     before do
-      expect(fake_octokit_client).to receive(:labels_for_issue).at_least(:once).with(repo_name, 2248).and_return(labels_for_2248)
+      expect(fake_octokit_client).to receive(:labels_for_issue).at_least(:once).with(repo_name, 2248).and_return(blocked_and_wip)
       expect(fake_octokit_client).to receive(:labels_for_issue).at_least(:once).with(repo_name, 2266).and_return([])
 
-      expected_open_prs['Remove all Import-related code']['labels'] = labels_for_2248
+      expected_open_prs['Remove all Import-related code']['labels'] = blocked_and_wip if expected_open_prs['Remove all Import-related code']
     end
 
-    it_behaves_like 'fetching from GitHub'
+    context 'excluding nothing' do
+      it_behaves_like 'fetching from GitHub'
+    end
+
+    context 'excluding "designer" label' do
+      let(:exclude_labels) { ['designer'] }
+
+      it_behaves_like 'fetching from GitHub'
+    end
+
+    context 'excluding "wip" label' do
+      let(:exclude_labels) { ['wip'] }
+
+      it 'filters out the WIP' do
+        expect(github_fetcher.list_pull_requests.keys).to include '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host'
+        expect(github_fetcher.list_pull_requests.keys).not_to include 'Remove all Import-related code'
+      end
+    end
   end
 
   context 'labels turned off' do

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -30,7 +30,6 @@ describe MessageBuilder do
   end
 
   before { Timecop.freeze(Time.local(2015, 07, 18)) }
-  after { Timecop.return }
 
   context 'with labels' do
     let(:mood) { 'informative' }

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -6,10 +6,57 @@ describe MessageBuilder do
   subject(:message_builder) { MessageBuilder.new(pull_requests, mood) }
 
   let(:no_pull_requests) { {} }
-  let(:old_pull_requests)   { { '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host' => { 'title' => '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host', 'link' => 'https://github.com/alphagov/whitehall/pull/2266', 'author' => 'mattbostock', 'repo' => 'whitehall', 'comments_count' => '1', 'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)') }, 'Remove all Import-related code' => { 'title' => 'Remove all Import-related code', 'link' => 'https://github.com/alphagov/whitehall/pull/2248', 'author' => 'tekin', 'repo' => 'whitehall', 'comments_count' => '5', 'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)') } } }
+  let(:old_pull_requests) do
+    {
+      '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host' => {
+        'title' => '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
+        'link' => 'https://github.com/alphagov/whitehall/pull/2266',
+        'author' => 'mattbostock',
+        'repo' => 'whitehall',
+        'comments_count' => '1',
+        'updated' => Date.parse('2015-07-13 ((2457217j, 0s, 0n), +0s, 2299161j)'),
+        'labels' => []
+      },
+      'Remove all Import-related code' => {
+        'title' => 'Remove all Import-related code',
+        'link' => 'https://github.com/alphagov/whitehall/pull/2248',
+        'author' => 'tekin',
+        'repo' => 'whitehall',
+        'comments_count' => '5',
+        'updated' => Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
+        'labels' => []
+      }
+    }
+  end
 
   before { Timecop.freeze(Time.local(2015, 07, 18)) }
   after { Timecop.return }
+
+  context 'with labels' do
+    let(:mood) { 'informative' }
+    let(:pull_requests) do
+      {
+        'My WIP' => {
+          'title' => 'My WIP',
+          'link' => 'https://github.com/org/repo/pull/42',
+          'author' => 'Agatha Christie',
+          'repo' => 'repo',
+          'comments_count' => '0',
+          'updated' => Date.today,
+          'labels' => [
+            { 'name' => 'wip' },
+            { 'name' => 'blocked' }
+          ]
+        }
+      }
+    end
+
+    it 'includes the labels in the built message' do
+      expect(message_builder.build).to include(
+        '[wip] [blocked] <https://github.com/org/repo/pull/42|My WIP> - 0 comments'
+      )
+    end
+  end
 
   context 'informative' do
     let(:mood) { 'informative' }


### PR DESCRIPTION
Context
-------

Now that the Seal has been working hard at Envato for a week, the biggest request from my team is to not mention PRs that are labelled 'wip'. 

"To be done:" has "do not display [DO NOT MERGE] pull requests"

Changes
-------

 - Fetch labels for PRs from GitHub
 - Include labels in pull request lines
 - Make fetching labels optional since it's expensive
 - Allow teams to exclude PRs with certain labels
 - Allow hiding titles
 - Update changelog
 - Remove disused code