### PR TITLE
Remove a double new line after the PRs on the Angry Seal message

### DIFF
--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -39,7 +39,7 @@ class MessageBuilder
 
   def bark_about_old_pull_requests
     msg = old_pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
-    "AAAAAAARGH! #{these(old_pull_requests.length)} #{pr_plural(old_pull_requests.length)} not been updated in over 2 days.\n\n#{msg.join}\n\n Remember each time you time you forget to review your pull requests, a baby seal dies."
+    "AAAAAAARGH! #{these(old_pull_requests.length)} #{pr_plural(old_pull_requests.length)} not been updated in over 2 days.\n\n#{msg.join}\nRemember each time you time you forget to review your pull requests, a baby seal dies."
   end
 
   def list_pull_requests

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -84,7 +84,7 @@ describe MessageBuilder do
       let(:pull_requests) { old_pull_requests }
 
       it 'builds message' do
-        expect(message_builder.build).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock | updated 5 days ago\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\n\n Remember each time you time you forget to review your pull requests, a baby seal dies.")
+        expect(message_builder.build).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock | updated 5 days ago\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\nRemember each time you time you forget to review your pull requests, a baby seal dies.")
       end
     end
 


### PR DESCRIPTION
- This was inconsistent with the normal Seal new lines between the PRs
  and the ending message.