### PR TITLE
Upgrade Octokit to v4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 ruby "2.1.2"
 
 gem 'slack-poster', '~> 1.0.1'
-gem "octokit", "~> 3.0"
+gem "octokit", "~> 4.0"
 
 group :test do
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     method_source (0.8.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    octokit (3.8.0)
+    octokit (4.0.1)
       sawyer (~> 0.6.0, >= 0.5.3)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -51,7 +51,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  octokit (~> 3.0)
+  octokit (~> 4.0)
   pry-byebug
   rake
   rspec


### PR DESCRIPTION
Context
-------

````
[Tue 15/08/11 21:15 AEST][s018][x86_64/darwin14.3.0/14.4.0][5.0.8]
<paj@clacks:~/src/seal>
zsh/2 6997  (git)-[discovery]-% bundle exec bin/angry_seal.rb discovery
/Users/paj/src/seal/lib/github_fetcher.rb:54:in `labels': undefined method `number' for [:message, "Moved Permanently"]:Array (NoMethodError)
        from /Users/paj/src/seal/lib/github_fetcher.rb:64:in `hidden_labels'
        from /Users/paj/src/seal/lib/github_fetcher.rb:59:in `hidden?'
        from /Users/paj/src/seal/lib/github_fetcher.rb:24:in `block (2 levels) in list_pull_requests'
        from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/sawyer-0.6.0/lib/sawyer/resource.rb:125:in `each'
        from /opt/rubies/2.1.2/lib/ruby/gems/2.1.0/gems/sawyer-0.6.0/lib/sawyer/resource.rb:125:in `each'
        from /Users/paj/src/seal/lib/github_fetcher.rb:24:in `reject'
        from /Users/paj/src/seal/lib/github_fetcher.rb:24:in `block in list_pull_requests'
        from /Users/paj/src/seal/lib/github_fetcher.rb:22:in `each'
        from /Users/paj/src/seal/lib/github_fetcher.rb:22:in `list_pull_requests'
        from /Users/paj/src/seal/lib/seal.rb:40:in `pull_requests'
        from /Users/paj/src/seal/lib/seal.rb:19:in `bark'
        from bin/angry_seal.rb:5:in `<main>'
```

Change
------

Bump to version 4 handle [API redirects](https://developer.github.com/changes/2015-05-26-repository-redirects-are-coming/).

Cc
--

@gstamp