### PR TITLE
Bark at each team in the config if none provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Just run `rspec` in the command line
 - Optionally hide pull requests with certain phrases in the title
   (`exclude_titles` config list)
 
+19th of August
+- Seal will bark at all teams in the config if no team is specified as an
+  argument to `./bin/{angry,informative}_seal.rb`, making Heroku scheduling
+  easier.
+
 ## Tips
 
 How to list your organisation's repositories modified within the last year:

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+require './lib/seal'
+
+describe Seal do
+  subject(:seal) { described_class.new(team, mood) }
+  let(:mood) { 'angry' }
+
+  describe '#bark' do
+    before do
+      expect(YAML).to receive(:load_file).and_return(org_config)
+      expect(MessageBuilder).to receive(:new)
+        .exactly(number_of_teams).times
+        .and_return(instance_double(MessageBuilder, build: nil, poster_mood: mood))
+      expect(SlackPoster).to receive(:new)
+        .exactly(number_of_teams).times
+        .and_return(instance_double(SlackPoster, send_request: nil))
+    end
+
+    context 'given a team "tigers"' do
+      let(:team) { 'tigers' }
+      let(:number_of_teams) { 1 }
+      let(:org_config) do
+        {
+          'tigers' => {
+            'members' => [],
+            'repos' => ['stripes'],
+            'use_labels' => nil,
+            'exclude_labels' => nil,
+            'exclude_titles' => nil,
+          }
+        }
+      end
+
+      it 'fetches PRs for the tigers and only the tigers' do
+        expect(GithubFetcher)
+          .to receive(:new)
+          .with([], ['stripes'], nil, nil, nil)
+          .and_return(instance_double(GithubFetcher, list_pull_requests: []))
+
+        seal.bark
+      end
+    end
+
+    context 'given no team' do
+      let(:team) { nil }
+
+      context "but two teams, lions and tigers in the organisation's config" do
+        let(:number_of_teams) { 2 }
+        let(:org_config) do
+          {
+            'lion' => {
+              'members' => [],
+              'repos' => ['leo'],
+              'use_labels' => nil,
+              'exclude_labels' => nil,
+              'exclude_titles' => nil,
+            },
+            'tigers' => {
+              'members' => [],
+              'repos' => ['stripes'],
+              'use_labels' => nil,
+              'exclude_labels' => nil,
+              'exclude_titles' => nil,
+            }
+          }
+        end
+
+        it 'fetches PRs for the lions and the tigers' do
+          expect(GithubFetcher)
+            .to receive(:new)
+            .with([], ['leo'], nil, nil, nil)
+            .and_return(instance_double(GithubFetcher, list_pull_requests: []))
+
+          expect(GithubFetcher)
+            .to receive(:new)
+            .with([], ['stripes'], nil, nil, nil)
+            .and_return(instance_double(GithubFetcher, list_pull_requests: []))
+
+          seal.bark
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Context
=======

I'm lazy.

Much like I don't want to add and remove people as they join and leave a project (see https://github.com/binaryberry/seal/commit/0b59c77781b79bd06d38dc54898266892d0e85eb), I don't want to have to maintain Heroku schedulers (as neat as they are) each time somebody adds or removes a team.

Change
======

If a team is not specified, Seal will bark at all teams in its config. If a team is provided, Seal will just bark at that one, as before.