### PR TITLE
Have seal mood depend on number & age of PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Just run `rspec` in the command line
 - Seal now displays thumbs up when present in comments
 - Angry seal now looks angrier
 
+13th of September
+- Seal now has only one script to be triggered - will start either the angry seal, the informative seal or the seal of approval each day.
+
 ## Tips
 
 How to list your organisation's repositories modified within the last year:

--- a/bin/angry_seal.rb
+++ b/bin/angry_seal.rb
@@ -1,5 +1,0 @@
-#!/usr/bin/env ruby
-
-require './lib/seal'
-
-Seal.new(ARGV[0], 'angry').bark

--- a/bin/seal.rb
+++ b/bin/seal.rb
@@ -2,5 +2,4 @@
 
 require './lib/seal'
 
-Seal.new(ARGV[0], 'informative').bark
-
+Seal.new(ARGV[0]).bark

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -2,19 +2,20 @@ class MessageBuilder
 
   attr_accessor :pull_requests, :report, :mood, :poster_mood
 
-  def initialize(pull_requests, mood)
+  def initialize(pull_requests)
     @pull_requests = pull_requests
-    @mood = mood
   end
 
   def build
-    case mood
-    when 'informative'
-      informative
-    when 'angry'
-      angry
+    if !old_pull_requests.empty?
+      @poster_mood = "angry"
+      bark_about_old_pull_requests
+    elsif @pull_requests.empty?
+      @poster_mood = "approval"
+      no_pull_requests
     else
-      fail("This seal does not understand '#{mood}']")
+      @poster_mood = "informative"
+      list_pull_requests
     end
   end
 
@@ -95,25 +96,6 @@ class MessageBuilder
       "yesterday"
     else
       "#{days} days ago"
-    end
-  end
-
-  def informative
-    if @pull_requests.empty?
-      @poster_mood = "approval"
-      no_pull_requests
-    else
-      @poster_mood = "informative"
-      list_pull_requests
-    end
-  end
-
-  def angry
-    @poster_mood = "angry"
-    if old_pull_requests.empty?
-      ''
-    else
-      bark_about_old_pull_requests
     end
   end
 

--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -39,13 +39,17 @@ class MessageBuilder
   end
 
   def bark_about_old_pull_requests
-    msg = old_pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
-    "AAAAAAARGH! #{these(old_pull_requests.length)} #{pr_plural(old_pull_requests.length)} not been updated in over 2 days.\n\n#{msg.join}\nRemember each time you time you forget to review your pull requests, a baby seal dies."
+    angry_bark = old_pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
+    recent_pull_requests = @pull_requests.reject { |_title, pr| rotten?(pr) }
+    list_recent_pull_requests = recent_pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
+    informative_bark = "There are also these pull requests that need to be reviewed today:\n\n#{list_recent_pull_requests.join} " if !recent_pull_requests.empty?
+    "AAAAAAARGH! #{these(old_pull_requests.length)} #{pr_plural(old_pull_requests.length)} not been updated in over 2 days.\n\n#{angry_bark.join}\nRemember each time you time you forget to review your pull requests, a baby seal dies.
+    \n\n#{informative_bark}"
   end
 
   def list_pull_requests
-    msg = @pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
-    "Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n#{msg.join}\nMerry reviewing!"
+    message = @pull_requests.keys.each_with_index.map { |title, n| present(title, n + 1) }
+    "Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n#{message.join}\nMerry reviewing!"
   end
 
   def no_pull_requests

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -10,9 +10,8 @@ require './lib/slack_poster.rb'
 class Seal
   ORGANISATION ||= ENV['SEAL_ORGANISATION']
 
-  def initialize(team, mood)
+  def initialize(team)
     @team = team
-    @mood = mood
   end
 
   def bark
@@ -32,7 +31,7 @@ class Seal
   end
 
   def bark_at(team)
-    message_builder = MessageBuilder.new(pull_requests(team), mood)
+    message_builder = MessageBuilder.new(pull_requests(team))
     message = message_builder.build
     slack = SlackPoster.new(ENV['SLACK_WEBHOOK'], team_config(team)['channel'], message_builder.poster_mood)
     slack.send_request(message)

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -2,10 +2,25 @@ require 'spec_helper'
 require './lib/message_builder'
 
 describe MessageBuilder do
-  subject(:message_builder) { MessageBuilder.new(pull_requests, mood) }
+  subject(:message_builder) { MessageBuilder.new(pull_requests) }
 
   let(:no_pull_requests) { {} }
-  let(:old_pull_requests) do
+  let(:recent_pull_requests) do
+    {
+      'Remove all Import-related code' => {
+        'title' => 'Remove all Import-related code',
+        'link' => 'https://github.com/alphagov/whitehall/pull/2248',
+        'author' => 'tekin',
+        'repo' => 'whitehall',
+        'comments_count' => '5',
+        'thumbs_up' => '0',
+        'updated' => Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
+        'labels' => []
+      }
+    }
+  end
+
+  let(:old_and_new_pull_requests) do
     {
       '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host' => {
         'title' => '[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host',
@@ -59,42 +74,47 @@ describe MessageBuilder do
     end
   end
 
-  context 'informative' do
-    let(:mood) { 'informative' }
+  context 'pull requests are recent' do
+    let(:pull_requests) { recent_pull_requests }
 
-    context 'old pull requests' do
-      let(:pull_requests) { old_pull_requests }
-
-      it 'builds message' do
-        expect(message_builder.build).to eq("Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | mattbostock | updated 5 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n2) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
-      end
+    it 'builds informative message' do
+      expect(message_builder.build).to eq("Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
     end
 
-    context 'no PRs' do
-      let(:pull_requests) { no_pull_requests }
-
-      it 'builds happy message' do
-        expect(message_builder.build).to eq("Good morning team! It's a beautiful day! :happyseal: :happyseal: :happyseal:\n\nNo pull requests to review today! :rainbow: :sunny: :metal: :tada:")
-      end
+    it 'has an informative poster mood' do
+      message_builder.build
+      expect(message_builder.poster_mood).to eq("informative")
     end
   end
 
-  context 'angry' do
+  context 'no pull requests' do
+    let(:pull_requests) { no_pull_requests }
+
+    it 'builds seal of approval message' do
+      expect(message_builder.build).to eq("Good morning team! It's a beautiful day! :happyseal: :happyseal: :happyseal:\n\nNo pull requests to review today! :rainbow: :sunny: :metal: :tada:")
+    end
+
+    it 'has an approval poster mood' do
+      message_builder.build
+      expect(pull_requests).to eq({})
+      expect(message_builder.poster_mood).to eq("approval")
+    end
+
+  end
+
+  context 'there are some PR that are over 2 days old' do
     let(:mood) { 'angry' }
 
     context 'old pull requests' do
-      let(:pull_requests) { old_pull_requests }
+      let(:pull_requests) { old_and_new_pull_requests }
 
       it 'builds message' do
         expect(message_builder.build).to eq("AAAAAAARGH! This pull request has not been updated in over 2 days.\n\n1) *whitehall* | mattbostock | updated 5 days ago | 1 :+1:\n<https://github.com/alphagov/whitehall/pull/2266|[FOR DISCUSSION ONLY] Remove Whitehall.case_study_preview_host> - 1 comment\n\nRemember each time you time you forget to review your pull requests, a baby seal dies.")
       end
-    end
 
-    context 'no old PRs' do
-      let(:pull_requests) { no_pull_requests }
-
-      it 'produces an empty string' do
-        expect(message_builder.build).to be_empty
+      it 'has an angry poster mood' do
+        message_builder.build
+        expect(message_builder.poster_mood).to eq("angry")
       end
     end
 

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require './lib/seal'
 
 describe Seal do
-  subject(:seal) { described_class.new(team, mood) }
+  subject(:seal) { described_class.new(team) }
   let(:mood) { 'angry' }
 
   describe '#bark' do

--- a/spec/slack_poster_spec.rb
+++ b/spec/slack_poster_spec.rb
@@ -13,6 +13,7 @@ describe 'slack_poster' do
   context 'send_request' do
     before do
       expect(Slack::Poster).to receive(:new).and_return(fake_slack_poster)
+      Timecop.freeze(Time.local(2015, 07, 16))
     end
 
     it 'posts to Slack' do


### PR DESCRIPTION
At the moment, there is one angry_seal task to monitor old PRs, and an informative seal task to publish ongoing PRs. This means where there are old and new PRs, we get 2 seals posting immediately after one another. These changes ensure only one seal needs to post each day:

- If there are no PRs that day, seal of approval
- If there are PRs that have been updated less than 2 days ago,
informative seal
- If there is at least one PR that has been updated over 2 days ago,
angry seal, which lists both old PRs and (less angrily) the recent ones