### PR TITLE
Add mobaig to team finding things

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -98,6 +98,7 @@ finding-things:
     - bishboria
     - KushalP
     - markhurrell
+    - mobaig
     - rboulton
     - tijmenb
     - jackscotti


### PR DESCRIPTION
@mobaig isn't in the list, so his pull requests aren't shown by the seal.