### PR TITLE
Add Heroku deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ When that works, you can push the app to Heroku, add the GITHUB_TOKEN and SLACK_
 
 Any questions feel free to contact me on Twitter -  my handle is binaryberry
 
+## Deploy to Heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 ##How to run the tests?
 Just run `rspec` in the command line
 

--- a/app.json
+++ b/app.json
@@ -14,22 +14,22 @@
       "description": "Your Github token (obtainable at https://github.com/settings/tokens)"
     },
     "GITHUB_REPOS": {
-      "description": "Comma serperated list of repos to check"
+      "description": "Comma separated list of repos to check"
     },
     "GITHUB_MEMBERS": {
-      "description": "Comma serperated list of github members",
+      "description": "Comma separated list of github members",
       "required": false
     },
     "GITHUB_USE_LABELS": {
-      "description": "Comma serperated list of labels to include",
+      "description": "Comma separated list of labels to include",
       "required": false
     },
     "GITHUB_EXCLUDE_LABELS": {
-      "description": "Comma serperated list of labels to exclude",
+      "description": "Comma separated list of labels to exclude",
       "required": false
     },
     "GITHUB_EXCLUDE_TITLES": {
-      "description": "Comma serperated list of titles e.g (WIP) to exclude",
+      "description": "Comma separated list of titles e.g (WIP) to exclude",
       "required": false
     },
     "SLACK_WEBHOOK": {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,42 @@
+{
+  "name": "Seal: A Slack Github PR Bot",
+  "description": "A bot that notifies Slack about open GitHub PRs.",
+  "keywords": [
+    "slack",
+    "github"
+  ],
+  "repository": "https://github.com/binaryberry/seal",
+  "env": {
+    "SEAL_ORGANISATION": {
+      "description": "Your Github organisation name"
+    },
+    "GITHUB_TOKEN": {
+      "description": "Your Github token (obtainable at https://github.com/settings/tokens)"
+    },
+    "GITHUB_REPOS": {
+      "description": "Comma serperated list of repos to check"
+    },
+    "GITHUB_MEMBERS": {
+      "description": "Comma serperated list of github members",
+      "required": false
+    },
+    "GITHUB_USE_LABELS": {
+      "description": "Comma serperated list of labels to include",
+      "required": false
+    },
+    "GITHUB_EXCLUDE_LABELS": {
+      "description": "Comma serperated list of labels to exclude",
+      "required": false
+    },
+    "GITHUB_EXCLUDE_TITLES": {
+      "description": "Comma serperated list of titles e.g (WIP) to exclude",
+      "required": false
+    },
+    "SLACK_WEBHOOK": {
+      "description": "Your Slack Incoming Webhook token (obtainable at https://slack.com/services/new/incoming-webhook)"
+    },
+    "SLACK_CHANNEL": {
+      "description": "Slack channel to notify"
+    }
+  }
+}

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -23,7 +23,7 @@ class Seal
   attr_accessor :mood
 
   def teams
-    if @team.nil?
+    if @team.nil? && org_config
       org_config.keys
     else
       [@team]
@@ -33,26 +33,41 @@ class Seal
   def bark_at(team)
     message_builder = MessageBuilder.new(pull_requests(team))
     message = message_builder.build
-    slack = SlackPoster.new(ENV['SLACK_WEBHOOK'], team_config(team)['channel'], message_builder.poster_mood)
+    channel = ENV["SLACK_CHANNEL"] ? ENV["SLACK_CHANNEL"] : team_config(team)['channel']
+    slack = SlackPoster.new(ENV['SLACK_WEBHOOK'], channel, message_builder.poster_mood)
     slack.send_request(message)
   end
 
   def org_config
-    @org_config ||= YAML.load_file("./config/#{ORGANISATION}.yml")
+    @org_config ||= YAML.load_file('./config/#{ORGANISATION}.yml') if File.exist?('./config/#{ORGANISATION}.yml')
   end
 
   def pull_requests(team)
     config = team_config(team)
-    git = GithubFetcher.new(config['members'],
-                            config['repos'],
-                            config['use_labels'],
-                            config['exclude_labels'],
-                            config['exclude_titles']
+    if config
+      members = config['members']
+      repos = config['repos']
+      use_labels = config['use_labels']
+      exclude_labels = config['exclude_labels']
+      exclude_titles = config['exclude_titles']
+    else
+      members = ENV['GITHUB_MEMBERS'] ? ENV['GITHUB_MEMBERS'].split(',') : []
+      repos = ENV['GITHUB_REPOS'] ? ENV['GITHUB_REPOS'].split(',') : []
+      use_labels = ENV['GITHUB_USE_LABELS'] ? ENV['GITHUB_USE_LABELS'].split(',') : nil
+      exclude_labels = ENV['GITHUB_EXCLUDE_LABELS'] ? ENV['GITHUB_EXCLUDE_LABELS'].split(',') : nil
+      exclude_titles = ENV['GITHUB_EXCLUDE_TITLES'] ? ENV['GITHUB_EXCLUDE_TITLES'].split(',') : nil
+    end
+
+    git = GithubFetcher.new(members,
+                            repos,
+                            use_labels,
+                            exclude_labels,
+                            exclude_titles
                            )
     git.list_pull_requests
   end
 
   def team_config(team)
-    org_config[team]
+    org_config[team] if org_config
   end
 end

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -39,7 +39,7 @@ class Seal
   end
 
   def org_config
-    @org_config ||= YAML.load_file('./config/#{ORGANISATION}.yml') if File.exist?('./config/#{ORGANISATION}.yml')
+    @org_config ||= YAML.load_file("./config/#{ORGANISATION}.yml") if File.exist?("./config/#{ORGANISATION}.yml")
   end
 
   def pull_requests(team)


### PR DESCRIPTION
In order to deploy without modifying the config in the repo I added a number of
additional environment variables:

    SLACK_CHANNEL
    GITHUB_REPOS
    GITHUB_MEMBERS
    GITHUB_USE_LABELS
    GITHUB_EXCLUDE_LABELS
    GITHUB_EXCLUDE_TITLES

This only works in simple team structures (one channel for the whole team)