### PR TITLE
Added Heroku Scheduler to Heroku Deploy button

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,5 +38,8 @@
     "SLACK_CHANNEL": {
       "description": "Slack channel to notify"
     }
-  }
+  },
+  "addons": [
+    "scheduler"
+  ]
 }


### PR DESCRIPTION
Heroku Scheduler is used to run the bin scripts at regular intervals