### PR TITLE
Fix Seal spec

### DIFF
--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -8,8 +8,6 @@ require './lib/slack_poster.rb'
 
 # Entry point for the Seal!
 class Seal
-  ORGANISATION ||= ENV['SEAL_ORGANISATION']
-
   def initialize(team)
     @team = team
   end
@@ -39,7 +37,11 @@ class Seal
   end
 
   def org_config
-    @org_config ||= YAML.load_file("./config/#{ORGANISATION}.yml") if File.exist?("./config/#{ORGANISATION}.yml")
+    @org_config ||= YAML.load_file(configuration_filename) if File.exist?(configuration_filename)
+  end
+
+  def configuration_filename
+    @configuration_filename ||= "./config/#{ENV['SEAL_ORGANISATION']}.yml"
   end
 
   def pull_requests(team)

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -3,9 +3,31 @@ require './lib/seal'
 
 describe Seal do
   subject(:seal) { described_class.new(team) }
+  let(:org_config) do
+    {
+      'lion' => {
+        'members' => [],
+        'repos' => ['leo'],
+        'use_labels' => nil,
+        'exclude_labels' => nil,
+        'exclude_titles' => nil,
+      },
+      'tigers' => {
+        'members' => [],
+        'repos' => ['stripes'],
+        'use_labels' => nil,
+        'exclude_labels' => nil,
+        'exclude_titles' => nil,
+      }
+    }
+  end
 
   describe '#bark' do
     before do
+      expect(ENV).to receive(:[]).once.with('SEAL_ORGANISATION').and_return('navy')
+      expect(ENV).to receive(:[]).exactly(number_of_teams).times.with('SLACK_CHANNEL')
+      expect(ENV).to receive(:[]).exactly(number_of_teams).times.with('SLACK_WEBHOOK')
+      expect(File).to receive(:exist?).at_least(:once).with('./config/navy.yml').and_return(true)
       expect(YAML).to receive(:load_file).and_return(org_config)
       expect(MessageBuilder).to receive(:new)
         .exactly(number_of_teams).times
@@ -18,17 +40,6 @@ describe Seal do
     context 'given a team "tigers"' do
       let(:team) { 'tigers' }
       let(:number_of_teams) { 1 }
-      let(:org_config) do
-        {
-          'tigers' => {
-            'members' => [],
-            'repos' => ['stripes'],
-            'use_labels' => nil,
-            'exclude_labels' => nil,
-            'exclude_titles' => nil,
-          }
-        }
-      end
 
       it 'fetches PRs for the tigers and only the tigers' do
         expect(GithubFetcher)
@@ -45,24 +56,6 @@ describe Seal do
 
       context "but two teams, lions and tigers in the organisation's config" do
         let(:number_of_teams) { 2 }
-        let(:org_config) do
-          {
-            'lion' => {
-              'members' => [],
-              'repos' => ['leo'],
-              'use_labels' => nil,
-              'exclude_labels' => nil,
-              'exclude_titles' => nil,
-            },
-            'tigers' => {
-              'members' => [],
-              'repos' => ['stripes'],
-              'use_labels' => nil,
-              'exclude_labels' => nil,
-              'exclude_titles' => nil,
-            }
-          }
-        end
 
         it 'fetches PRs for the lions and the tigers' do
           expect(GithubFetcher)


### PR DESCRIPTION
Context
-------

https://github.com/binaryberry/seal/pull/31 [broke our CI](https://travis-ci.org/envato/seal/builds/83603855) when I [merged it into our own organisation's repo](https://github.com/envato/seal/pull/14).

It didn't break CI upstream because that CI environment sets [`export SEAL_ORGANISATION=alphagov`]( https://travis-ci.org/binaryberry/seal/builds/82113946#L89).

Change
------

Rather than enforce setting environment variables to run the specs, I've
stubbed `ENV`. This gives us greater control over the behaviour of the
class under test allowing us to check the file that would be loaded.

Considerations
--------------

The behaviour of the class using environment-based configuration for a
team remains untested.