### PR TITLE
Add TZ to optional environment variables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "octokit", "~> 4.0"
 group :test do
   gem 'guard'
   gem 'guard-rspec'
+  gem 'jsonlint'
   gem 'rake'
   gem 'rspec'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,8 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.3)
+    jsonlint (0.1.0)
+      oj (~> 2)
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -42,6 +44,7 @@ GEM
       shellany (~> 0.0)
     octokit (4.0.1)
       sawyer (~> 0.6.0, >= 0.5.3)
+    oj (2.12.14)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -82,6 +85,7 @@ PLATFORMS
 DEPENDENCIES
   guard
   guard-rspec
+  jsonlint
   octokit (~> 4.0)
   pry-byebug
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,22 @@ begin
   require 'rspec/core/rake_task'
 
   RSpec::Core::RakeTask.new(:spec)
-
-  task :default => :spec
 rescue LoadError
   # no rspec available
 end
+
+begin
+  require 'jsonlint/rake_task'
+  JsonLint::RakeTask.new do |t|
+    t.paths = %w(
+    *.json
+    )
+  end
+rescue LoadError
+  # no jsonlint available
+end
+
+task :default => [
+  :jsonlint,
+  :spec,
+]

--- a/app.json
+++ b/app.json
@@ -37,6 +37,10 @@
     },
     "SLACK_CHANNEL": {
       "description": "Slack channel to notify"
+    },
+    "TZ": {
+      "description": "The timezone within which Seal operates (e.g. Australia/Melbourne)",
+      "required": false
     }
   },
   "addons": [


### PR DESCRIPTION
Context
-------

We use Seal a long way from UTC, which means the age of PRs, weekends,
_et cetera_ need to be calculated taking our offset into account.

Change
------

- Use app.json to document TZ usage.
- Use jsonlint in CI to ensure app.json is valid.

See also
--------

https://en.wikipedia.org/wiki/List_of_tz_database_time_zones