### PR TITLE
Add API endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby "2.1.2"
 
 gem 'slack-poster', '~> 1.0.1'
 gem "octokit", "~> 4.0"
+gem "sinatra"
 
 group :test do
   gem 'guard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,9 @@ GEM
     pry-byebug (3.2.0)
       byebug (~> 5.0)
       pry (~> 0.10)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
     rake (10.4.2)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
@@ -73,10 +76,15 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     shellany (0.0.1)
+    sinatra (1.4.6)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     slack-poster (1.0.1)
       httparty (~> 0.12)
     slop (3.6.0)
     thor (0.19.1)
+    tilt (2.0.1)
     timecop (0.8.0)
 
 PLATFORMS
@@ -90,8 +98,6 @@ DEPENDENCIES
   pry-byebug
   rake
   rspec
+  sinatra
   slack-poster (~> 1.0.1)
   timecop
-
-BUNDLED WITH
-   1.10.6

--- a/server.rb
+++ b/server.rb
@@ -1,0 +1,9 @@
+require 'sinatra'
+require './lib/seal'
+require './lib/github_fetcher'
+require './lib/message_builder'
+require './lib/slack_poster'
+
+get '/seal' do
+  Seal.new("core-formats").bark
+end


### PR DESCRIPTION
This is to work with alphagov/gds-hubot and allow the Seal report to be produced via Hubot.