### PR TITLE
Use github search to power pull request search

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,10 +13,6 @@
     "GITHUB_TOKEN": {
       "description": "Your Github token (obtainable at https://github.com/settings/tokens)"
     },
-    "GITHUB_REPOS": {
-      "description": "Comma separated list of repos to check",
-      "required": false
-    },
     "GITHUB_MEMBERS": {
       "description": "Comma separated list of github members",
       "required": false

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -9,40 +9,6 @@ core-formats:
     - fofr
     - jamiecobbett
 
-  repos:
-    - Accessible-Media-Player
-    - asset-manager
-    - content-register
-    - content-store
-    - deprecated_columns
-    - external-link-tracker
-    - feedback
-    - frontend
-    - gds_zendesk
-    - government-frontend
-    - govuk_admin_template
-    - govuk_content_api
-    - govuk-content-schemas
-    - govuk_content_models
-    - govuk_need_api
-    - info-frontend
-    - maslow
-    - metadata-api
-    - panopticon
-    - publisher
-    - release
-    - router-api
-    - short-url-manager
-    - signonotron2
-    - specialist-frontend
-    - specialist-publisher
-    - static
-    - support
-    - support-api
-    - travel-advice-publisher
-    - url-arbiter
-    - whitehall
-
   channel:
     "#core-formats"
 
@@ -62,37 +28,6 @@ custom:
     - h-lame
     - davidbasalla
 
-  repos:
-    - business-support-api
-    - calendars
-    - contacts-admin
-    - contacts-frontend
-    - content-register
-    - content-store
-    - courts-api
-    - courts-frontend
-    - govuk-content-schemas
-    - hmrc-manuals-api
-    - imminence
-    - licence-finder
-    - manuals-frontend
-    - mapit
-    - optic14n
-    - pre-transition-stats
-    - publishing-api
-    - side-by-side-browser
-    - smart-answers
-    - specialist-publisher
-    - static
-    - trade-tariff-admin
-    - trade-tariff-backend
-    - trade-tariff-frontend
-    - transition
-    - transition-config
-    - transition-stats
-    - url-arbiter
-    - whitehall
-
   channel:
     "#custom"
 
@@ -110,45 +45,6 @@ finding-things:
     - rboulton
     - stephen-richards
     - tijmenb
-    
-  repos:
-    - collections
-    - collections-publisher
-    - content-store
-    - content-tagger
-    - email-alert-api
-    - email-alert-monitor
-    - finder-frontend
-    - govdelivery-email-templates
-    - government-service-design-manual
-    - govuk_content_api
-    - govuk_content_models
-    - govuk_message_queue_consumer
-    - govuk_migration_plan_public
-    - govuk_mirror-puppet
-    - govuk_prototype_kit
-    - govuk-content-best-practices
-    - govuk-content-schema-test-helpers
-    - govuk-content-schemas
-    - panopticon
-    - payment-prototype-options
-    - policy-publisher
-    - prototyping
-    - publishing-api
-    - recommended-links
-    - release
-    - router
-    - rummager
-    - search-admin
-    - search-performance-dashboard
-    - smokey
-    - specialist-publisher
-    - static
-    - styleguides
-    - support
-    - support-api
-    - tagging-migration-verifier
-    - whitehall
 
   channel:
     "#finding-things"
@@ -166,34 +62,6 @@ testing:
     - boffbowsh
     - fofr
     - jamiecobbett
-
-  repos:
-    - Accessible-Media-Player
-    - asset-manager
-    - content-register
-    - content-store
-    - external-link-tracker
-    - feedback
-    - frontend
-    - government-frontend
-    - govuk_content_api
-    - govuk-content-schemas
-    - info-frontend
-    - maslow
-    - metadata-api
-    - panopticon
-    - publisher
-    - release
-    - short-url-manager
-    - signonotron2
-    - specialist-frontend
-    - specialist-publisher
-    - static
-    - support
-    - support-api
-    - travel-advice-publisher
-    - url-arbiter
-    - whitehall
 
   channel:
     "#testing"

--- a/config/envato.yml
+++ b/config/envato.yml
@@ -1,35 +1,10 @@
 envato-market:
   channel: '#marketplacedev'
   members: []
-  repos:
-    - db_backup
-    - docs
-    - envato.com
-    - front-end-coding-test
-    - market-dev-expectations
-    - marketplace
-    - marketplace-puppet
-    - new-coding-test
-    - ops-coding-test
-    - our-boxen
-    - webuild.envato.com
   use_labels: true
   exclude_labels:
     - wip
 discovery:
   channel: '#discovery-notify'
   members: []
-  repos:
-    - discovery
-    - solid_octane
-    - solid_octane_service
-    - dewey
-    - discovery-scheduler
-    - recommender-api
-    - api-gateway
-    - build.envato.com
-    - search_public_api
-    - discovery_users
-    - ami-builder
-    - discovery-docker
   use_labels: false

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -48,20 +48,17 @@ class Seal
     config = team_config(team)
     if config
       members = config['members']
-      repos = config['repos']
       use_labels = config['use_labels']
       exclude_labels = config['exclude_labels']
       exclude_titles = config['exclude_titles']
     else
       members = ENV['GITHUB_MEMBERS'] ? ENV['GITHUB_MEMBERS'].split(',') : []
-      repos = ENV['GITHUB_REPOS'] ? ENV['GITHUB_REPOS'].split(',') : []
       use_labels = ENV['GITHUB_USE_LABELS'] ? ENV['GITHUB_USE_LABELS'].split(',') : nil
       exclude_labels = ENV['GITHUB_EXCLUDE_LABELS'] ? ENV['GITHUB_EXCLUDE_LABELS'].split(',') : nil
       exclude_titles = ENV['GITHUB_EXCLUDE_TITLES'] ? ENV['GITHUB_EXCLUDE_TITLES'].split(',') : nil
     end
 
     git = GithubFetcher.new(members,
-                            repos,
                             use_labels,
                             exclude_labels,
                             exclude_titles

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -4,7 +4,6 @@ require './lib/github_fetcher'
 describe 'GithubFetcher' do
   subject(:github_fetcher) do
     GithubFetcher.new(team_members_accounts,
-                      team_repos,
                       use_labels,
                       exclude_labels,
                       exclude_titles
@@ -58,7 +57,6 @@ describe 'GithubFetcher' do
   let(:exclude_labels) { nil }
   let(:exclude_titles) { nil }
   let(:team_members_accounts) { %w(binaryberry boffbowsh jackscotti tekin elliotcm tommyp mattbostock) }
-  let(:team_repos) { %w(whitehall) }
   let(:pull_2266) do
     double(Sawyer::Resource,
            user: double(Sawyer::Resource, login: 'mattbostock'),
@@ -97,7 +95,7 @@ describe 'GithubFetcher' do
   before do
     expect(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
     expect(fake_octokit_client).to receive_message_chain('user.login')
-    expect(fake_octokit_client).to receive(:pull_requests).with(repo_name, :state => 'open').and_return([pull_2266, pull_2248])
+    expect(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov").and_return(double(items: [pull_2266, pull_2248]))
 
     allow(fake_octokit_client).to receive(:issue_comments).with(repo_name, 2266).and_return(comments_2266)
     allow(fake_octokit_client).to receive(:issue_comments).with(repo_name, 2248).and_return(comments_2248)

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -7,14 +7,12 @@ describe Seal do
     {
       'lion' => {
         'members' => [],
-        'repos' => ['leo'],
         'use_labels' => nil,
         'exclude_labels' => nil,
         'exclude_titles' => nil,
       },
       'tigers' => {
         'members' => [],
-        'repos' => ['stripes'],
         'use_labels' => nil,
         'exclude_labels' => nil,
         'exclude_titles' => nil,
@@ -44,7 +42,7 @@ describe Seal do
       it 'fetches PRs for the tigers and only the tigers' do
         expect(GithubFetcher)
           .to receive(:new)
-          .with([], ['stripes'], nil, nil, nil)
+          .with([], nil, nil, nil)
           .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
         seal.bark
@@ -60,12 +58,12 @@ describe Seal do
         it 'fetches PRs for the lions and the tigers' do
           expect(GithubFetcher)
             .to receive(:new)
-            .with([], ['leo'], nil, nil, nil)
+            .with([], nil, nil, nil)
             .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
           expect(GithubFetcher)
             .to receive(:new)
-            .with([], ['stripes'], nil, nil, nil)
+            .with([], nil, nil, nil)
             .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
           seal.bark

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@
 #
 require 'timecop'
 
+ENV['SEAL_ORGANISATION'] ||= "alphagov"
+
 RSpec.configure do |config|
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Currently, the seal loops through all repos and fetches all pull requests. We could replace this with the issue search: https://developer.github.com/v3/search/#search-issues

This will return all open PRs in all alphagov repos. It uses the same search syntax as github.com.

This means 1) we can get rid of the repos in the configuration, 2) new repos are added automatically, 3) we save a bunch of requests.

Closes: #52