### PR TITLE
Let seal see more pull requests

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -41,8 +41,10 @@ class GithubFetcher
     pr
   end
 
+  # https://developer.github.com/v3/search/#search-issues
+  # returns up to 100 results per page.
   def pull_requests_from_github
-    @github.search_issues("is:pr state:open user:#{ORGANISATION}").items
+    @github.search_issues("is:pr state:open user:#{ORGANISATION}", per_page: 100).items
   end
 
   def person_subscribed?(pull_request)

--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -14,18 +14,27 @@ class SlackPoster
   end
 
   def create_poster
-    @poster = Slack::Poster.new("#{webhook_url}", options = {
-      icon_emoji: @mood_hash[:icon_emoji],
-      username: @mood_hash[:username],
-      channel: @team_channel
-    })
+    @poster = Slack::Poster.new("#{webhook_url}", slack_options)
   end
 
   def send_request(message)
-    poster.send_message("#{message}") unless Date.today.saturday? || Date.today.sunday?
+    if ENV['DRY']
+      puts slack_options.inspect
+      puts message
+    else
+      poster.send_message("#{message}") unless Date.today.saturday? || Date.today.sunday?
+    end
   end
 
   private
+
+  def slack_options
+    {
+     icon_emoji: @mood_hash[:icon_emoji],
+     username: @mood_hash[:username],
+     channel: @team_channel
+   }
+  end
 
   def mood_hash
     @mood_hash = {}

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -95,7 +95,7 @@ describe 'GithubFetcher' do
   before do
     expect(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
     expect(fake_octokit_client).to receive_message_chain('user.login')
-    expect(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov").and_return(double(items: [pull_2266, pull_2248]))
+    expect(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov", per_page: 100).and_return(double(items: [pull_2266, pull_2248]))
 
     allow(fake_octokit_client).to receive(:issue_comments).with(repo_name, 2266).and_return(comments_2266)
     allow(fake_octokit_client).to receive(:issue_comments).with(repo_name, 2248).and_return(comments_2248)


### PR DESCRIPTION
It turns out `#search_issues` returns 30 results per default. This caused the seal to report on only the 30 most recent pull requests in the organisation.

This commit fixes this by increasing that number to 100, the maximum of requests per page according to the API docs (and experimentation). This should take care of most missing pull requests.

Also adds a option (`DRY=1`) to the seal so that testing is a little easier.

Closes #73 