### PR TITLE
Fix auto-pagination bug

### DIFF
--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -8,7 +8,7 @@ class GithubFetcher
   def initialize(team_members_accounts, use_labels, exclude_labels, exclude_titles)
     @github = Octokit::Client.new(:access_token => ENV['GITHUB_TOKEN'])
     @github.user.login
-    Octokit.auto_paginate = true
+    @github.auto_paginate = true
     @people = team_members_accounts
     @use_labels = use_labels
     @exclude_labels = exclude_labels.map(&:downcase).uniq if exclude_labels
@@ -44,7 +44,7 @@ class GithubFetcher
   # https://developer.github.com/v3/search/#search-issues
   # returns up to 100 results per page.
   def pull_requests_from_github
-    @github.search_issues("is:pr state:open user:#{ORGANISATION}", per_page: 100).items
+    @github.search_issues("is:pr state:open user:#{ORGANISATION}").items
   end
 
   def person_subscribed?(pull_request)

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -95,7 +95,8 @@ describe 'GithubFetcher' do
   before do
     expect(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
     expect(fake_octokit_client).to receive_message_chain('user.login')
-    expect(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov", per_page: 100).and_return(double(items: [pull_2266, pull_2248]))
+    expect(fake_octokit_client).to receive(:auto_paginate=).with(true)
+    expect(fake_octokit_client).to receive(:search_issues).with("is:pr state:open user:alphagov").and_return(double(items: [pull_2266, pull_2248]))
 
     allow(fake_octokit_client).to receive(:issue_comments).with(repo_name, 2266).and_return(comments_2266)
     allow(fake_octokit_client).to receive(:issue_comments).with(repo_name, 2248).and_return(comments_2248)


### PR DESCRIPTION
The auto-paginate method needed to be called on the instance of the client
instead of the Octokit class. This means it's no longer necessary to specify
the 100 items limit as the client will go through all the pages, and set the 100
items limit per page by default.

This means this will now pull all the PRs of an organisation, not just the 100 most recent ones!

cc @tijmenb @johnsyweb @boffbowsh @monfresh