### PR TITLE
fix typo in my name

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -52,7 +52,7 @@ specialist-publisher:
   members:
     - mathildathompson
     - Rosa-Fox
-    - christopherwong
+    - christophwong
 
   channel:
     "#specialist-publisher"


### PR DESCRIPTION
my github account name uses the german spelling of christopher