### PR TITLE
Ignore unfinished PRs for the govuk-infrastructure team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -163,6 +163,10 @@ govuk-infrastructure:
   channel:
     "#govuk-infrastructure"
 
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - WIP
+
   quotes:
     - ":eggplant:"
     - "indeed"


### PR DESCRIPTION
We're finding the seal helpful but we'd also like somewhere to hide unfinished code from its gaze.