### PR TITLE
Fix yml indentation

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -58,7 +58,7 @@ specialist-publisher:
   channel:
     "#specialist-publisher"
 
-    exclude_titles:
+  exclude_titles:
     - "[DO NOT MERGE]"
     - WIP
 


### PR DESCRIPTION
The "exclude_titles" in specialist-publisher was not indented correctly, which broke several seals.

YAML is very unforgiving with indentation.

cc @sihugh  (but the seal still :heart: s you!)