### PR TITLE
Allow excluding prs based on repo

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -83,6 +83,9 @@ custom:
     - DO NOT MERGE
     - WIP
 
+  exclude_repos:
+    - e-petitions
+
 finding-things:
   members:
     - benhyland

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -55,24 +55,27 @@ class Seal
       use_labels = config['use_labels']
       exclude_labels = config['exclude_labels']
       exclude_titles = config['exclude_titles']
+      exclude_repos = config['exclude_repos']
       @quotes = config['quotes']
     else
       members = ENV['GITHUB_MEMBERS'] ? ENV['GITHUB_MEMBERS'].split(',') : []
       use_labels = ENV['GITHUB_USE_LABELS'] ? ENV['GITHUB_USE_LABELS'].split(',') : nil
       exclude_labels = ENV['GITHUB_EXCLUDE_LABELS'] ? ENV['GITHUB_EXCLUDE_LABELS'].split(',') : nil
       exclude_titles = ENV['GITHUB_EXCLUDE_TITLES'] ? ENV['GITHUB_EXCLUDE_TITLES'].split(',') : nil
+      exclude_repos = ENV['GITHUB_EXCLUDE_REPOS'] ? ENV['GITHUB_EXCLUDE_REPOS'].split(',') : nil
       @quotes = ENV['SEAL_QUOTES'] ? ENV['SEAL_QUOTES'].split(',') : nil
     end
-    return fetch_from_github(members, use_labels, exclude_labels, exclude_titles) if @mode == nil
+    return fetch_from_github(members, use_labels, exclude_labels, exclude_titles, exclude_repos) if @mode == nil
     @quotes
   end
 
 
-def fetch_from_github(members, use_labels, exclude_labels, exclude_titles)
+  def fetch_from_github(members, use_labels, exclude_labels, exclude_titles, exclude_repos)
     git = GithubFetcher.new(members,
                             use_labels,
                             exclude_labels,
-                            exclude_titles
+                            exclude_titles,
+                            exclude_repos
                            )
     git.list_pull_requests
   end

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -10,12 +10,14 @@ describe Seal do
         'use_labels' => nil,
         'exclude_labels' => nil,
         'exclude_titles' => nil,
+        'exclude_repos' => nil,
       },
       'tigers' => {
         'members' => [],
         'use_labels' => nil,
         'exclude_labels' => nil,
         'exclude_titles' => nil,
+        'exclude_repos' => nil,
       }
     }
   end
@@ -42,7 +44,7 @@ describe Seal do
       it 'fetches PRs for the tigers and only the tigers' do
         expect(GithubFetcher)
           .to receive(:new)
-          .with([], nil, nil, nil)
+          .with([], nil, nil, nil, nil)
           .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
         seal.bark
@@ -58,12 +60,12 @@ describe Seal do
         it 'fetches PRs for the lions and the tigers' do
           expect(GithubFetcher)
             .to receive(:new)
-            .with([], nil, nil, nil)
+            .with([], nil, nil, nil, nil)
             .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
           expect(GithubFetcher)
             .to receive(:new)
-            .with([], nil, nil, nil)
+            .with([], nil, nil, nil, nil)
             .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
           seal.bark


### PR DESCRIPTION
I'm in the custom team but I also happen to work on a repo that lives in the same github organisation, but is not of interest to anyone else in the team.  It would be nice to filter that repo out of our seal to avoid being barked at when there's nothing anyone in the team can do as they don't have responsibility for that repo.  This PR adds that functionality and configures the custom team to ignore that repo.