### PR TITLE
remove non-active team members of specialist-publisher

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -50,13 +50,8 @@ core-formats:
 
 specialist-publisher:
   members:
-    - benilovj
     - christophwong
-    - danielroseman
-    - mathildathompson
-    - rgarner
     - Rosa-Fox
-    - tahb
 
   channel:
     "#specialist-publisher"


### PR DESCRIPTION
we are only getting angry seals now for PR on other team's repo.