### PR TITLE
Chris has two different github user name

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -54,7 +54,6 @@ specialist-publisher:
     - Rosa-Fox
     - Seraphiana
     - tuzz
-    - chrislee
     - Chrislee187
 
   channel:

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -55,6 +55,7 @@ specialist-publisher:
     - Seraphiana
     - tuzz
     - chrislee
+    - Chrislee187
 
   channel:
     "#specialist-publisher"


### PR DESCRIPTION
~~one for github dot com and dot gds~~
Removed incorrect `github.gds` username and add correct `github.com` username for new member on specialist-publisher team. 