### PR TITLE
Add hubot integration

### DIFF
--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -58,11 +58,11 @@ class MessageBuilder
 
   def list_pull_requests
     message = @content.keys.each_with_index.map { |title, n| present(title, n + 1) }
-    "Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n#{message.join}\nMerry reviewing!"
+    "Hello team! \n\n Here are the pull requests that need to be reviewed today:\n\n#{message.join}\nMerry reviewing!"
   end
 
   def no_pull_requests
-    "Good morning team! It's a beautiful day! :happyseal: :happyseal: :happyseal:\n\nNo pull requests to review today! :rainbow: :sunny: :metal: :tada:"
+    "Aloha team! It's a beautiful day! :happyseal: :happyseal: :happyseal:\n\nNo pull requests to review today! :rainbow: :sunny: :metal: :tada:"
   end
 
   def bark_about_quotes

--- a/server.rb
+++ b/server.rb
@@ -9,11 +9,11 @@ class SealApp < Sinatra::Base
   get '/' do
     "Hello Seal"
   end
-  # POST /teams/core-formats
 
-
-  post '/teams/?:team_name?' do
-    Seal.new(params[:team_name]).bark
+  post '/bark/:team_name/:secret' do
+    if params[:secret] == ENV["SEAL_SECRET"]
+      Seal.new(params[:team_name]).bark
+      "Seal received message with #{params[:team_name]} team name"
+    end
   end
-
 end

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -78,7 +78,7 @@ describe MessageBuilder do
     let(:pull_requests) { recent_pull_requests }
 
     it 'builds informative message' do
-      expect(message_builder.build).to eq("Good morning team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
+      expect(message_builder.build).to eq("Hello team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
     end
 
     it 'has an informative poster mood' do
@@ -91,7 +91,7 @@ describe MessageBuilder do
     let(:pull_requests) { no_pull_requests }
 
     it 'builds seal of approval message' do
-      expect(message_builder.build).to eq("Good morning team! It's a beautiful day! :happyseal: :happyseal: :happyseal:\n\nNo pull requests to review today! :rainbow: :sunny: :metal: :tada:")
+      expect(message_builder.build).to eq("Aloha team! It's a beautiful day! :happyseal: :happyseal: :happyseal:\n\nNo pull requests to review today! :rainbow: :sunny: :metal: :tada:")
     end
 
     it 'has an approval poster mood' do


### PR DESCRIPTION
Also adds a message that confirms the url has been hit (for debugging
purposes) and requests secret key to trigger the seal.

I've tested these changes locally and by deploying the branch, then triggering hubot through the bin/hubot console, and all seems to work well.

I'll be merging this once my PR on gds-hubot has been merged, so I can try it live.