### PR TITLE
Fix yaml spacing error

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -225,12 +225,12 @@ servicemanual:
 
   quotes:
     - ":wave:"
-    
+
 templateconsolidation:
   members:
     - nickcolley
     - miaallers
     - markhurrell
 
- channel:
+  channel:
     "#templateconsolidation"

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,19 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/usr/local/bin/node', '/usr/local/bin/npm', 'run', 'start' ]
+2 info using npm@2.15.9
+3 info using node@v4.5.0
+4 verbose stack Error: ENOENT: no such file or directory, open '/Users/tatianasoukiassian/govuk/seal/package.json'
+4 verbose stack     at Error (native)
+5 verbose cwd /Users/tatianasoukiassian/govuk/seal
+6 error Darwin 14.5.0
+7 error argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "start"
+8 error node v4.5.0
+9 error npm  v2.15.9
+10 error path /Users/tatianasoukiassian/govuk/seal/package.json
+11 error code ENOENT
+12 error errno -2
+13 error syscall open
+14 error enoent ENOENT: no such file or directory, open '/Users/tatianasoukiassian/govuk/seal/package.json'
+14 error enoent This is most likely not a problem with npm itself
+14 error enoent and is related to npm not being able to find a file.
+15 verbose exit [ -2, true ]


### PR DESCRIPTION
A space was missing before the channel key of the template consolidation team, which made all the seal jobs fail. Oh, YAML.

Adding a yaml linter to the CI pipeline would be a good idea, but I am hoping to stop using YAML in the future and store the team's configuration in a database so I'll put up with the mistake risk for now, unless someone wants to open a PR.