### PR TITLE
Move Chris & Tatiana to Custom

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -2,7 +2,6 @@
 
 core-formats:
   members:
-    - binaryberry
     - steventux
     - boffbowsh
     - fofr
@@ -51,6 +50,7 @@ core-formats:
 
 custom:
   members:
+    - binaryberry
     - brenetic
     - davidbasalla
     - deborahchua
@@ -59,6 +59,7 @@ custom:
     - jennyd
     - sihugh
     - whoojemaflip
+    - cbaines
 
   channel:
     "#custom"
@@ -144,7 +145,6 @@ publishing-platform:
   members:
     - danielroseman
     - kevindew
-    - cbaines
     - carlosmartinez
     - dougdroper
 


### PR DESCRIPTION
Whilst they are there as part of the mainstream pop-up team.

I wasn't sure maybe you needed to split custom into some people that would use the #custom channel and some that would use the #mainstream-pop-up channel. That seemed a bit more destructive though so let me know if it should be edited to that.

I see that Jenny is still on [the wiki](https://gov-uk.atlassian.net/wiki/display/GOVUK/Product+group+structure+and+details) as part of custom so I thought she could remain there rather than setting up an email team where she is the only developer.