### PR TITLE
Remove gemmaleigh from the service manual team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -205,7 +205,6 @@ govuk-infrastructure:
 
 servicemanual:
   members:
-    - gemmaleigh
     - thehenster
     - 36degrees
 


### PR DESCRIPTION
This is causing lots of alerts in the service manual channel about frontend alpha PRs, as the service manual team doesn't want to know about these - remove gemmaleigh from the list of members.