### PR TITLE
Eliminate Jen's vestigial remains

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -43,7 +43,7 @@ core-formats:
     - When working at home, dial in to stand-up
     - Keep things up-to-date - like the digital wall, team calendar
     - Communicate what you’re working on - make sure you don’t leave people out of the loop
-    - Trello should reflect what everyone’s working on - if it's going to take longer than 30 minutes or it's going to need to be deployed - write a card and chat with Jen.
+    - Trello should reflect what everyone’s working on - if it's going to take longer than 30 minutes or it's going to need to be deployed - write a card and chat with Shilpa.
     - Meetings must have a clear purpose and make the best use of everyone’s time
     - Keep our desks and work spaces tidy (including the tea stand)
     - Get involved with user research - everyone should spend 2 hours every 6 weeks learning about our users


### PR DESCRIPTION
When [Jen regenerated into Shilpa][1], we experienced a rift in the space-time continuum resulting in them both having corporeal representations in the same plane of existence (the seal).  This must be resolved prior to the annual multiverse reconciliation date or we may all be annihilated.

There can be only one.

[1]: https://github.com/binaryberry/seal/commit/60500a4f9f7fe7184cf4ecb5d5a729299b856dcf