### PR TITLE
Add Content Tools

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-teams=(core-formats
+teams=(content-tools
+       core-formats
        publishing-platform
        govuk-infrastructure)
 

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-teams=(core-formats
+teams=(content-tools
+       core-formats
        publishing-platform
        specialist-publisher
        finding-things

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -1,5 +1,48 @@
 # Please insert new items alphabetically.
 
+content-tools:
+  members:
+    - pmanrubia
+    - leenagupte
+    - ikennaokpala
+    - theleebriggs
+    - chao-xian
+
+  channel:
+    "#content-tools"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "Don't merge"
+    - DO NOT MERGE
+
+  quotes:
+    - Everyone should have the opportunity to learn. Don’t be afraid to pick up stories on things you don’t understand and ask for help with them.
+    - We focus on users - always starting with ‘why’ we are doing something, not ‘what’ we are doing.
+    - If it’s gonna take more than 30 minutes, or it needs deploying - write a card for it and chat to the Product Manager.
+    - Try to pair when possible.
+    - Pick up work from the 'ready column' - don't cherry pick from the backlog/ice box or ‘next’ column.
+    - Any excuse for cake - or generally celebrating awesomeness
+    - Never be afraid to suggest better ways of working.
+    - Be nice and respect each other. Support each other.
+    - Don’t be a silo of knowledge
+    - Ask if anyone needs support before picking up new work
+    - Be considerate to remote workers
+    - Avoid gendered language when it isn’t needed
+    - Turn up to meetings on time, one person speaks at a time
+    - Stories should start with a user need
+    - It’s not done until it’s in the hands of the people who need it
+    - When working at home, dial in to stand-up
+    - Keep things up-to-date - like the digital wall, team calendar
+    - Communicate what you’re working on - make sure you don’t leave people out of the loop
+    - Trello should reflect what everyone’s working on - if it's going to take longer than 30 minutes or it's going to need to be deployed - write a card and chat with the Product Manager.
+    - Meetings must have a clear purpose and make the best use of everyone’s time
+    - Keep our desks and work spaces tidy (including the tea stand)
+    - Get involved with user research - everyone should spend 2 hours every 6 weeks learning about our users
+    - The Dragon needs slaying
+    - Is it time for Chilango?
+    - If you're not well, don't come in to the office.
+
 core-formats:
   members:
     - steventux


### PR DESCRIPTION
The Content Tools team now look after a bunch of apps that many others issue PRs on. We need to be more aware of these and have Seal prompt us.

I’ve added the team to the `config.yml` with our current members, the labels I think we’d want to ignore (Do not merge) and have stolen the Core Format team’s charter for quotes.

I think I've done this right - I couldn't see anything else where I'd need to configure.