### PR TITLE
Show check mark when PRs are approved.

### DIFF
--- a/lib/message_builder.rb
+++ b/lib/message_builder.rb
@@ -95,8 +95,9 @@ class MessageBuilder
     days = age_in_days(pr)
     thumbs_up = ''
     thumbs_up = " | #{pr["thumbs_up"].to_i} :+1:" if pr["thumbs_up"].to_i > 0
+    approved = pr["approved"] ? " | :white_check_mark: " : ""
     <<-EOF.gsub(/^\s+/, '')
-    #{index}\) *#{pr["repo"]}* | #{pr["author"]} | updated #{days_plural(days)}#{thumbs_up}
+    #{index}\) *#{pr["repo"]}* | #{pr["author"]} | updated #{days_plural(days)}#{thumbs_up}#{approved}
     #{labels(pr)} <#{pr["link"]}|#{pr["title"]}> - #{pr["comments_count"]}#{comments(pull_request)}
     EOF
   end

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -39,6 +39,7 @@ describe 'GithubFetcher' do
           'repo' => 'whitehall',
           'comments_count' => '1',
           'thumbs_up' => '1',
+          'approved' => false,
           'updated' => Date.parse('2015-07-13 ((2457217j,0s,0n),+0s,2299161j)'),
           'labels' => []
         },
@@ -51,6 +52,7 @@ describe 'GithubFetcher' do
           'repo' => 'whitehall-rebuild',
           'comments_count' => '5',
           'thumbs_up' => '0',
+          'approved' => true,
           'updated' => Date.parse('2015-07-17 ((2457221j,0s,0n),+0s,2299161j)'),
           'labels' => []
         }
@@ -95,6 +97,14 @@ describe 'GithubFetcher' do
     ].map { |body| double(Sawyer::Resource, body: body)}
   end
 
+  let(:reviews_2248) do
+    [
+      double(Sawyer::Resource, state: "APPROVED" )
+    ]
+  end
+
+  let(:reviews_2266) { [] }
+
   before do
     expect(Octokit::Client).to receive(:new).and_return(fake_octokit_client)
     expect(fake_octokit_client).to receive_message_chain('user.login')
@@ -106,6 +116,8 @@ describe 'GithubFetcher' do
 
     allow(fake_octokit_client).to receive(:pull_request).with(whitehall_rebuild_repo_name, 2248).and_return(pull_2248)
     allow(fake_octokit_client).to receive(:pull_request).with(whitehall_repo_name, 2266).and_return(pull_2266)
+    allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2248/reviews").and_return(reviews_2248)
+    allow(fake_octokit_client).to receive(:get).with(%r"repos/alphagov/[\w-]+/pulls/2266/reviews").and_return(reviews_2266)
   end
 
   shared_examples_for 'fetching from GitHub' do

--- a/spec/message_builder_spec.rb
+++ b/spec/message_builder_spec.rb
@@ -14,6 +14,7 @@ describe MessageBuilder do
         'repo' => 'whitehall',
         'comments_count' => '5',
         'thumbs_up' => '0',
+        'approved' => true,
         'updated' => Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
         'labels' => []
       }
@@ -29,6 +30,7 @@ describe MessageBuilder do
         'repo' => 'whitehall',
         'comments_count' => '1',
         'thumbs_up' => '1',
+        'approved' => false,
         'updated' => Date.parse('2015-07-13 ((2457217j, 0s, 0n), +0s, 2299161j)'),
         'labels' => []
       },
@@ -39,6 +41,7 @@ describe MessageBuilder do
         'repo' => 'whitehall',
         'comments_count' => '5',
         'thumbs_up' => '0',
+        'approved' => false,
         'updated' => Date.parse('2015-07-17 ((2457221j, 0s, 0n), +0s, 2299161j)'),
         'labels' => []
       }
@@ -58,6 +61,7 @@ describe MessageBuilder do
           'repo' => 'repo',
           'comments_count' => '0',
           'thumbs_up' => '0',
+          'approved' => false,
           'updated' => Date.today,
           'labels' => [
             { 'name' => 'wip' },
@@ -78,7 +82,7 @@ describe MessageBuilder do
     let(:pull_requests) { recent_pull_requests }
 
     it 'builds informative message' do
-      expect(message_builder.build).to eq("Hello team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday\n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
+      expect(message_builder.build).to eq("Hello team! \n\n Here are the pull requests that need to be reviewed today:\n\n1) *whitehall* | tekin | updated yesterday | :white_check_mark: \n<https://github.com/alphagov/whitehall/pull/2248|Remove all Import-related code> - 5 comments\n\nMerry reviewing!")
     end
 
     it 'has an informative poster mood' do


### PR DESCRIPTION
Many teams are now using Github's new review workflow, where you
explicitly approve a PR rather than marking it with a +1. This is now
supported in their API as a preview function via a specific media type
header.

This change adds a green check mark for PRs that are approved in this
way.