### PR TITLE
Set flag to exclude labels

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -17,6 +17,8 @@ content-tools:
     - DO NOT MERGE
     - "Waiting on factcheck"
 
+  use_labels: true
+
   exclude_labels:
     - "[DO NOT MERGE]"
     - "Don't merge"
@@ -25,29 +27,10 @@ content-tools:
 
   quotes:
     - Everyone should have the opportunity to learn. Don’t be afraid to pick up stories on things you don’t understand and ask for help with them.
-    - We focus on users - always starting with ‘why’ we are doing something, not ‘what’ we are doing.
     - If it’s gonna take more than 30 minutes, or it needs deploying - write a card for it and chat to the Product Manager.
     - Try to pair when possible.
-    - Pick up work from the 'ready column' - don't cherry pick from the backlog/ice box or ‘next’ column.
-    - Any excuse for cake - or generally celebrating awesomeness
-    - Never be afraid to suggest better ways of working.
-    - Be nice and respect each other. Support each other.
-    - Don’t be a silo of knowledge
-    - Ask if anyone needs support before picking up new work
-    - Be considerate to remote workers
-    - Avoid gendered language when it isn’t needed
-    - Turn up to meetings on time, one person speaks at a time
-    - Stories should start with a user need
-    - It’s not done until it’s in the hands of the people who need it
-    - When working at home, dial in to stand-up
-    - Keep things up-to-date - like the digital wall, team calendar
-    - Communicate what you’re working on - make sure you don’t leave people out of the loop
-    - Trello should reflect what everyone’s working on - if it's going to take longer than 30 minutes or it's going to need to be deployed - write a card and chat with the Product Manager.
-    - Meetings must have a clear purpose and make the best use of everyone’s time
-    - Keep our desks and work spaces tidy (including the tea stand)
-    - Get involved with user research - everyone should spend 2 hours every 6 weeks learning about our users
-    - The Dragon needs slaying
-    - Is it time for Chilango?
+    - Be considerate to remote workers and follow the Working from home practices https://gov-uk.atlassian.net/wiki/x/Bz_5Bw
+    - Who's organising the next team lunch?
     - If you're not well, don't come in to the office.
 
 core-formats:

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -16,6 +16,7 @@ content-tools:
     - "Don't merge"
     - DO NOT MERGE
     - "Waiting on factcheck"
+    - WIP
 
   use_labels: true
 


### PR DESCRIPTION
I don’t know how I didn’t spot this but I missed out a flag to make
Seal exclude the labels. I’ve also tidied up my team’s quotes to be less
plagiaristic.