### PR TITLE
Re-add email team to alphagov config

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -5,6 +5,7 @@ teams=(content-tools
        publishing-platform
        specialist-publisher
        finding-things
+       email
        custom
        govuk-infrastructure
        mainstream-pop-up

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -136,9 +136,19 @@ finding-things:
 email:
   members:
     - jennyd
+    - dwhenry
+    - carolinegreen
 
   channel:
     "#email"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "Don't merge"
+    - DO NOT MERGE
+    - WIP
+    - "[REVIEW ONLY]"
+    - REVIEW ONLY
 
 testing:
   members:


### PR DESCRIPTION
We are writing code, and we are more people now :)