### PR TITLE
Add spec for alphagov.yml

### DIFF
--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'config/alphagov.yml' do
+  it 'is valid YAML' do
+    config = YAML.load_file('config/alphagov.yml')
+
+    expect(config).to be_a(Hash)
+  end
+end


### PR DESCRIPTION
This adds a test for our config. Makes sure that we don't put in invalid YAML.