### PR TITLE
Fix taxonomy team name

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -73,7 +73,7 @@ navigation:
     - "[REVIEW ONLY]"
     - REVIEW ONLY
 
-content-transformation:
+taxonomy:
   members:
     - andrewgarner
     - klssmith


### PR DESCRIPTION
This prevents `seal me up` from working.