### PR TITLE
Add hold government to account team

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -6,6 +6,7 @@ teams=(
   navigation
   content-transformation
   email
+  hold-gov-to-account
   search
   govuk-infrastructure
   servicemanual

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -53,6 +53,22 @@ content-tools:
     - Don't forget the Jabra and fisheye lens if you're dialing in people!
     - If Hangouts is being flaky, try Slack calls or appear.in!
 
+hold-gov-to-account:
+  members:
+    - kevindew
+    - thomasleese
+    - emmabeynon
+    - steventux
+    - leenagupte
+    - bevanloon
+
+  channel:
+    "#support-holdgovtoacc"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - WIP
+
 navigation:
   members:
     - alecgibson


### PR DESCRIPTION
Combination of developers from Content History and Scrutineers, as we'll be
sharing a trello board and channel be good to keep the PRs together.