### PR TITLE
The team roster has changed slightly.

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -156,11 +156,8 @@ testing:
 
 govuk-infrastructure:
   members:
-    - alexmuller
     - deanwilson
-    - rjw1
     - surminus
-    - djsd123
     - afda16
     - SamLR
 


### PR DESCRIPTION
Remove the people that have changed roles from the govuk-infrastructure
team as we don't need to see their PRs