### PR TITLE
Make the team name match slack for search

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -109,7 +109,7 @@ email:
     - "[REVIEW ONLY]"
     - REVIEW ONLY
 
-search:
+search-team:
   members:
     - matmoore
     - brenetic


### PR DESCRIPTION
The mismatch prevents the "seal me up" command from working.
See https://github.com/binaryberry/seal/pull/173