### PR TITLE
Make seal pick up my PRs

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -127,7 +127,7 @@ email:
 
 search-team:
   members:
-    - matmoore
+    - MatMoore
     - brenetic
     - suzannehamilton
     - dwhenry


### PR DESCRIPTION
The seal was not returning my PRs - I think because the filter
is case sensitive.