### PR TITLE
Show PRs that are ready for review

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -82,12 +82,7 @@ navigation:
     "#navigation"
 
   exclude_titles:
-    - "[DO NOT MERGE]"
-    - "Don't merge"
-    - DO NOT MERGE
     - WIP
-    - "[REVIEW ONLY]"
-    - REVIEW ONLY
 
 taxonomy:
   members:


### PR DESCRIPTION
The navigation team would like to see all PRs that are open, apart from
WIP PRs, so that we can start early reviews. Most times the DO NOT MERGE
tag is only there to coordinate deploys or get early feedback, so it's
important to see that.