### PR TITLE
Move Bevan to his new team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -60,7 +60,6 @@ hold-gov-to-account:
     - emmabeynon
     - steventux
     - leenagupte
-    - bevanloon
 
   channel:
     "#support-holdgovtoacc"
@@ -216,6 +215,7 @@ worldwide-publishing:
     - gpeng
     - mgrassotti
     - rubenarakelyan
+    - bevanloon
 
   channel:
     "#worldwide-publishing"


### PR DESCRIPTION
He has moved from Holding Government to Account to Worldwide Publishing.