### PR TITLE
Add async calculation for server call

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -12,8 +12,10 @@ class SealApp < Sinatra::Base
 
   post '/bark/:team_name/:secret' do
     if params[:secret] == ENV["SEAL_SECRET"]
-      Seal.new(params[:team_name]).bark
-      "Seal received message with #{params[:team_name]} team name"
+      Thread.start do
+        Seal.new(params[:team_name]).bark
+      end
+      "Just a second..."
     end
   end
 


### PR DESCRIPTION
### Description

I wanted to make Seal respond to on demand request. So I added a slack `slash command` to my team's slack. https://api.slack.com/custom-integrations/slash-commands

The problem with the current implementation is that our Seal takes its time to answer, so Slack times out without an answer showing an error to the user. With this change, the invoker receives a `Just a second...` message while the list of PRs is built.

Tested on heroku. Works great.

### Screenshot

![screenshot from 2017-07-03 19-27-18](https://user-images.githubusercontent.com/1465872/27809420-c470adae-6025-11e7-9d59-7483b9b0003c.png)
