### PR TITLE
Add new devs to Content Tools

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -17,10 +17,11 @@ benchmarking:
 content-tools:
   members:
     - pmanrubia
-    - cbaines
     - ikennaokpala
     - chao-xian
     - mgrassotti
+    - andrewgarner
+    - alecgibson 
 
   channel:
     "#content-tools"
@@ -98,7 +99,7 @@ navigation:
 
 taxonomy:
   members:
-    - andrewgarner
+    - cbaines
     - klssmith
     - tijmenb
     - whoojemaflip


### PR DESCRIPTION
Swap @cbaines with @andrewgarner on Taxonomy.

Leave @alecgibson on Navigation also as they are only paused.