### PR TITLE
Add Chris Patuzzo to Email team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -57,6 +57,7 @@ email:
     - davidbasalla
     - gpeng
     - rubenarakelyan
+    - tuzz
 
   channel:
     "#email"


### PR DESCRIPTION
Chris is now a part of the Email team.