### PR TITLE
Remove Worldwide Publishing from morning seal

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -11,7 +11,6 @@ teams=(
   govuk-infrastructure
   servicemanual
   templateconsolidation
-  worldwide-publishing
 )
 
 for team in ${teams[*]}; do


### PR DESCRIPTION
This team no longer exists.