### PR TITLE
Change hold-gov-to-account team to content-api

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -67,17 +67,16 @@ email:
     - "[DO NOT MERGE]"
     - "[WIP]"
 
-hold-gov-to-account:
+content-api:
   members:
     - kevindew
     - thomasleese
     - emmabeynon
     - steventux
-    - leenagupte
-    - bevanloon
+    - klssmith
 
   channel:
-    "#support-holdgovtoacc"
+    "#content-api"
 
   exclude_titles:
     - "[DO NOT MERGE]"


### PR DESCRIPTION
Scruitineers now has its own section so Leena and Bevan are there, and
Katie has joined.