### PR TITLE
Add "[SEAL IGNORE]" to exclude_titles

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -102,6 +102,7 @@ taxonomy:
     - WIP
     - "[REVIEW ONLY]"
     - REVIEW ONLY
+    - "[SEAL IGNORE]"
 
 search-team:
   members:


### PR DESCRIPTION
For the taxonomy team, as it would be useful to get the seal to ignore some Pull Requests, but none of the other exclude titles are applicable.