### PR TITLE
Update search and frontend teams

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -7,10 +7,10 @@ teams=(
   taxonomy
   email
   hold-gov-to-account
-  search
+  search-team
   govuk-infrastructure
   servicemanual
-  templateconsolidation
+  publishing-frontend
 )
 
 for team in ${teams[*]}; do

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -195,18 +195,16 @@ servicemanual:
   quotes:
     - ":wave:"
 
-templateconsolidation:
+publishing-frontend:
   members:
     - nickcolley
     - miaallers
-    - markhurrell
-    - michaelihejirika
-    - theleebriggs
+    - andysellick
+    - vanitabarrett
     - fofr
-    - mcgoooo
 
   channel:
-    "#templateconsolidation"
+    "#publishing-frontend"
 
   exclude_titles:
     - "[DO NOT MERGE]"


### PR DESCRIPTION
The template consolidation team has become the publishing-frontend team, and has new members. Although the search-team had the correct name in the config, that name also needed to be corrected in `morning_seal.sh`.