### PR TITLE
Revert "Add async calculation for server call"

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -12,10 +12,8 @@ class SealApp < Sinatra::Base
 
   post '/bark/:team_name/:secret' do
     if params[:secret] == ENV["SEAL_SECRET"]
-      Thread.start do
-        Seal.new(params[:team_name]).bark
-      end
-      "Just a second..."
+      Seal.new(params[:team_name]).bark
+      "Seal received message with #{params[:team_name]} team name"
     end
   end
 


### PR DESCRIPTION
Reverts binaryberry/seal#193

Reverting this for now as it causes issues for us, it seems each time we use the endpoint, it runs the seal for all the teams in our config - we think it's because we need to pass the param into the thread, otherwise the contents of the param change before the thread. So we think running Thread.start(params[:team_name]) { |team_name| ... } would solve it.