### PR TITLE
Benchmarking renamed to Modeling Services

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 teams=(
-  benchmarking
+  modelling-services
   content-tools
   navigation
   taxonomy

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -1,13 +1,14 @@
 # Please insert new items alphabetically.
 
-benchmarking:
+modelling-services:
   members:
     - Davidslv
     - deborahchua
     - sihugh
+    - andysellick
 
   channel:
-    "#benchmarking"
+    "#modelling-services"
 
   exclude_titles:
     - "[DO NOT MERGE]"


### PR DESCRIPTION
We recently changed our channel name, this commit is to reflect that.
I also added Andy into our channel.