### PR TITLE
Update the email team for Q3 2017

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -62,9 +62,11 @@ content-tools:
 email:
   members:
     - 1pretz1
-    - davidbasalla
+    - bevanloon
     - gpeng
+    - kevindew
     - rubenarakelyan
+    - thomasleese
     - tuzz
 
   channel:
@@ -76,8 +78,6 @@ email:
 
 content-api:
   members:
-    - kevindew
-    - thomasleese
     - emmabeynon
     - steventux
 


### PR DESCRIPTION
This commit updates the email team for Q3 2017:

* Add Kevin Dew, Thomas Leese and Bevan Loon
* Remove David Basalla