### PR TITLE
Possibly fix dependabot's GH username

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -246,10 +246,10 @@ publishing-frontend:
 
 govuk-madetech:
   members:
+    - app/dependabot
     - chrisblackburn
     - danielburnley
     - davidwinter
-    - dependabot
     - idabmat
     - lukemorton
     - naliwajek


### PR DESCRIPTION
If you click on the username it seems to be "app/dependabot" internally:

https://github.com/alphagov/feedback/pulls/app/dependabot