### PR TITLE
Add seal for the "Making it easier to find things" objective in GOV.UK

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 teams=(
+  govuk-easier-finding
   govuk-infrastructure
   search-team
   content-tools

--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -259,3 +259,28 @@ govuk-madetech:
 
   channel:
     "#govuk-madetech"
+
+# The objective with Start pages, Frontend navigation & Modelling services
+govuk-easier-finding:
+  members:
+    - alextea
+    - andysellick
+    - Davidslv
+    - deborahchua
+    - emmabeynon
+    - fofr
+    - leenagupte
+    - maxgds
+    - miaallers
+    - nickcolley
+    - sihugh
+    - steventux
+    - tijmenb
+    - vanitabarrett
+
+  channel:
+    "#govuk-easier-finding"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "WIP"


### PR DESCRIPTION
A secondary channel to get visibility on code review status across the "Making it easier to find things" objective in GOV.UK.

Contains the same people as Start pages, Frontend navigation & Modelling services.