### PR TITLE
Remove Chris Patuzzo from Email team

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -66,7 +66,6 @@ email:
     - kevindew
     - rubenarakelyan
     - thomasleese
-    - tuzz
 
   channel:
     "#email"


### PR DESCRIPTION
He's moving to Reliability Engineering