### PR TITLE
Remove govuk-easier-finding from afternoon seal

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -2,7 +2,6 @@
 
 teams=(
   content-tools
-  govuk-easier-finding
   reliability-engineering
   servicemanual
 )


### PR DESCRIPTION
Afternoon seal only posts quotes and this team doesn't have any defined.