### PR TITLE
Remove navigation team from morning seal

### DIFF
--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -6,7 +6,6 @@ teams=(
   frontend-design
   govuk-madetech
   modelling-services
-  navigation
   platform_support
   publishing-frontend
   reliability-engineering


### PR DESCRIPTION
This team no longer exists.