### PR TITLE
Change team name in schedules

### DIFF
--- a/bin/afternoon_seal.sh
+++ b/bin/afternoon_seal.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 teams=(
-  content-tools
+  data-informed-content
   modelling-services
   reliability-engineering
 )

--- a/bin/morning_seal.sh
+++ b/bin/morning_seal.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 teams=(
-  content-tools
+  data-informed-content
   email
   frontend-design
   govuk-design-system


### PR DESCRIPTION
When I changed the Content Tools team into Data Informed Content,
I forgot to also change the name in the config files for when the
bot should run.