### PR TITLE
Adds option to filter already-reviewed pull requests, regardless of approval status

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ export SLACK_WEBHOOK="get_your_incoming_webhook_link_for_your_slack_group_channe
 export SLACK_CHANNEL="#whatever-channel-you-prefer"
 export GITHUB_MEMBERS="netflash,binaryberry,otheruser"
 export GITHUB_USE_LABELS=true
+export GITHUB_EXCLUDE_REVIEWED=true
 export GITHUB_EXCLUDE_LABELS="[DO NOT MERGE],Don't merge,DO NOT MERGE,Waiting on factcheck,wip"
 export GITHUB_EXCLUDE_REPOS="notmyproject,someotherproject" # Ensure these projects are *NOT* included
 export GITHUB_INCLUDE_REPOS="definitelymyproject,forsuremyproject" # Ensure *only* these projects will be included
@@ -106,6 +107,7 @@ docker run -it --rm --name seal \
   -e DYNO=${DYNO} \
   -e SLACK_CHANNEL=${SLACK_CHANNEL} \
   -e GITHUB_MEMBERS=${GITHUB_MEMBERS} \
+  -e GITHUB_EXCLUDE_REVIEWED=${GITHUB_EXCLUDE_REVIEWED} \
   -e GITHUB_USE_LABELS=${GITHUB_USE_LABELS} \
   -e "GITHUB_EXCLUDE_LABELS=${GITHUB_EXCLUDE_LABELS}" \
   -e "SEAL_QUOTES=${SEAL_QUOTES}" \
@@ -219,6 +221,9 @@ docker run -it --rm --name seal \
 
 6th of January
 - Seal can now post random quotes from the team's list of quotes in the config. Can be used as a reminder or for inspirational quotes!
+
+7th of February
+- Seal can exclude pull requests that have been already reviewed by at least one peer, regardless of approval status
 
 ## Tips
 

--- a/lib/seal.rb
+++ b/lib/seal.rb
@@ -57,6 +57,7 @@ class Seal
       exclude_titles = config['exclude_titles']
       exclude_repos = config['exclude_repos']
       include_repos = config['include_repos']
+      exclude_reviewed = config['exclude_reviewed']
       @quotes = config['quotes']
     else
       members = ENV['GITHUB_MEMBERS'] ? ENV['GITHUB_MEMBERS'].split(',') : []
@@ -65,20 +66,22 @@ class Seal
       exclude_titles = ENV['GITHUB_EXCLUDE_TITLES'] ? ENV['GITHUB_EXCLUDE_TITLES'].split(',') : nil
       exclude_repos = ENV['GITHUB_EXCLUDE_REPOS'] ? ENV['GITHUB_EXCLUDE_REPOS'].split(',') : nil
       include_repos = ENV['GITHUB_INCLUDE_REPOS'] ? ENV['GITHUB_INCLUDE_REPOS'].split(',') : nil
+      exclude_reviewed = ENV['GITHUB_EXCLUDE_REVIEWED'] ? true : false
       @quotes = ENV['SEAL_QUOTES'] ? ENV['SEAL_QUOTES'].split(',') : nil
     end
-    return fetch_from_github(members, use_labels, exclude_labels, exclude_titles, exclude_repos, include_repos) if @mode == nil
+    return fetch_from_github(members, use_labels, exclude_labels, exclude_titles, exclude_repos, include_repos, exclude_reviewed) if @mode == nil
     @quotes
   end
 
 
-  def fetch_from_github(members, use_labels, exclude_labels, exclude_titles, exclude_repos, include_repos)
+  def fetch_from_github(members, use_labels, exclude_labels, exclude_titles, exclude_repos, include_repos, exclude_reviewed)
     git = GithubFetcher.new(members,
                             use_labels,
                             exclude_labels,
                             exclude_titles,
                             exclude_repos,
-                            include_repos
+                            include_repos,
+                            exclude_reviewed
                            )
     git.list_pull_requests
   end

--- a/spec/github_fetcher_spec.rb
+++ b/spec/github_fetcher_spec.rb
@@ -8,7 +8,8 @@ describe 'GithubFetcher' do
                       exclude_labels,
                       exclude_titles,
                       exclude_repos,
-                      include_repos
+                      include_repos,
+                      exclude_reviewed
                      )
   end
 
@@ -63,6 +64,7 @@ describe 'GithubFetcher' do
   let(:exclude_titles) { nil }
   let(:exclude_repos) { nil }
   let(:include_repos) { nil }
+  let(:exclude_reviewed) { nil }
   let(:team_members_accounts) { %w(binaryberry boffbowsh jackscotti tekin elliotcm tommyp mattbostock) }
   let(:pull_2266) do
     double(Sawyer::Resource,

--- a/spec/seal_spec.rb
+++ b/spec/seal_spec.rb
@@ -12,6 +12,7 @@ describe Seal do
         'exclude_titles' => nil,
         'exclude_repos' => nil,
         'include_repos' => nil,
+        'exclude_reviewed' => nil,
       },
       'tigers' => {
         'members' => [],
@@ -20,6 +21,7 @@ describe Seal do
         'exclude_titles' => nil,
         'exclude_repos' => nil,
         'include_repos' => nil,
+        'exclude_reviewed' => nil,
       }
     }
   end
@@ -46,7 +48,7 @@ describe Seal do
       it 'fetches PRs for the tigers and only the tigers' do
         expect(GithubFetcher)
           .to receive(:new)
-          .with([], nil, nil, nil, nil, nil)
+          .with([], nil, nil, nil, nil, nil, nil)
           .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
         seal.bark
@@ -62,12 +64,12 @@ describe Seal do
         it 'fetches PRs for the lions and the tigers' do
           expect(GithubFetcher)
             .to receive(:new)
-            .with([], nil, nil, nil, nil, nil)
+            .with([], nil, nil, nil, nil, nil, nil)
             .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
           expect(GithubFetcher)
             .to receive(:new)
-            .with([], nil, nil, nil, nil, nil)
+            .with([], nil, nil, nil, nil, nil, nil)
             .and_return(instance_double(GithubFetcher, list_pull_requests: []))
 
           seal.bark


### PR DESCRIPTION
Since the GitHub API now gives you review status, I felt it was prudent to suggest this.

This helps cut down the list so that only PRs that have no reviews at all get listed, as a PR with zero feedback is the blocker I'm looking to address -- its merge status or approval is less urgent in my use case.

I figured this would be useful to others, feel free to make suggestions for changes, and thank you for this cool bot!