### PR TITLE
Added support for passing in Github API endpoint in env

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ In your shell profile, put in:
 export SEAL_ORGANISATION="your_github_organisation"
 export GITHUB_TOKEN="get_your_github_token_from_yourgithub_settings"
 export SLACK_WEBHOOK="get_your_incoming_webhook_link_for_your_slack_group_channel"
+export GITHUB_API_ENDPOINT="your_github_api_endpoint" # OPTIONAL If you are using a Github Enterprise instance
 ```
 
 ### Env variables
@@ -35,6 +36,7 @@ In your shell profile, put in:
 ```sh
 export SEAL_ORGANISATION="your_github_organisation"
 export GITHUB_TOKEN="get_your_github_token_from_yourgithub_settings"
+export GITHUB_API_ENDPOINT="your_github_api_endpoint" # OPTIONAL If you are using a Github Enterprise instance
 export SLACK_WEBHOOK="get_your_incoming_webhook_link_for_your_slack_group_channel"
 export SLACK_CHANNEL="#whatever-channel-you-prefer"
 export GITHUB_MEMBERS="netflash,binaryberry,otheruser"
@@ -102,6 +104,7 @@ And then run it (assuming you already set all the env variables)
 docker run -it --rm --name seal \
   -e "SEAL_ORGANISATION=${SEAL_ORGANISATION}" \
   -e GITHUB_TOKEN=${GITHUB_TOKEN} \
+  -e GITHUB_API_ENDPOINT=${GITHUB_API_ENDPOINT} \
   -e SLACK_WEBHOOK=${SLACK_WEBHOOK} \
   -e DYNO=${DYNO} \
   -e SLACK_CHANNEL=${SLACK_CHANNEL} \

--- a/app.json
+++ b/app.json
@@ -13,6 +13,9 @@
     "GITHUB_TOKEN": {
       "description": "Your Github token (obtainable at https://github.com/settings/tokens)"
     },
+    "GITHUB_API_ENDPOINT": {
+      "description": "OPTIONAL. If you are using a Github Enterprise instance instead of public github.com i.e https://github.yourcompany.com/api/v3"
+    },
     "GITHUB_MEMBERS": {
       "description": "Comma separated list of github members",
       "required": false

--- a/lib/github_fetcher.rb
+++ b/lib/github_fetcher.rb
@@ -9,6 +9,7 @@ class GithubFetcher
 
   def initialize(team_members_accounts, use_labels, exclude_labels, exclude_titles, exclude_repos, include_repos)
     @github = Octokit::Client.new(:access_token => ENV['GITHUB_TOKEN'])
+    @github.api_endpoint = ENV['GITHUB_API_ENDPOINT'] if ENV['GITHUB_API_ENDPOINT']
     @github.user.login
     @github.auto_paginate = true
     @people = team_members_accounts


### PR DESCRIPTION
- Added support for optionally using a custom Github API endpoint for use with Github Enterprises instances
- Param is passed in as the `GITHUB_API_ENDPOINT` environment variable