### PR TITLE
Remove Andrew from Data Informed Content

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -2,13 +2,12 @@
 
 data-informed-content:
   members:
-    - andrewgarner
     - chao-xian
     - kylemacpherson
-    - pmanrubia
-    - theKHutDeveloper
     - matmoore
     - peteglondon
+    - pmanrubia
+    - theKHutDeveloper
 
   channel:
     "#data-informed-content"


### PR DESCRIPTION
Andrew has moved to DATA.GOV.UK.