### PR TITLE
Delete Dean, add Roch

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -180,9 +180,9 @@ publishing-frontend:
 reliability-engineering:
   members:
     - afda16
-    - deanwilson
     - issyl0
     - jljalderman
+    - rtrinque
     - stephenharker
     - surminus
     - suthagahrt


### PR DESCRIPTION
Dean works in a dedicated Tools channel and the Seal seems to be committed to GOV.UK team members at the moment, so remove him.

Add Roch /cc @rtrinque