### PR TITLE
Add licensing support channel

### DIFF
--- a/config/alphagov.yml
+++ b/config/alphagov.yml
@@ -238,3 +238,17 @@ testing:
     - Everyone should have the opportunity to learn. Don’t be afraid to pick up stories on things you don’t understand and ask for help with them.
     - Be nice and respect each other. Support each other.
     - Don’t be a silo of knowledge
+    
+gov-uk-licensing-support:
+  members:
+    - PeteLeaman
+    - SomniGiggles
+    - steven-radford
+    - chrispapto
+    
+  channel:
+    "#govuk-licensing"
+
+  exclude_titles:
+    - "[DO NOT MERGE]"
+    - "[WIP]"


### PR DESCRIPTION
- Add the Licensify support team and it's govuk channel