### PR TITLE
Raise an exception if Slack posting fails

### DIFF
--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -29,7 +29,7 @@ class SlackPoster
     else
       if postable_day
         response = poster.send_message(message)
-	raise SlackResponseError, "Posting to webhook failed with: #{response.status} #{response.reason_phrase} #{response.body}" unless response.success?
+        raise SlackResponseError, "Posting to webhook failed with: #{response.status} #{response.reason_phrase} #{response.body}" unless response.success?
       end
     end
   end

--- a/lib/slack_poster.rb
+++ b/lib/slack_poster.rb
@@ -2,6 +2,8 @@ require 'slack-poster'
 
 class SlackPoster
 
+  SlackResponseError = Class.new(StandardError)
+
   attr_accessor :webhook_url, :poster, :mood, :mood_hash, :channel, :season_name, :halloween_season, :festive_season
 
   def initialize(webhook_url, team_channel, mood)
@@ -25,7 +27,10 @@ class SlackPoster
       puts slack_options.inspect
       puts message
     else
-      poster.send_message(message) if postable_day
+      if postable_day
+        response = poster.send_message(message)
+	raise SlackResponseError, "Posting to webhook failed with: #{response.status} #{response.reason_phrase} #{response.body}" unless response.success?
+      end
     end
   end
 


### PR DESCRIPTION
## Context

We had an issue where our webhook was no longer able to post to arbitrary channels, due to a permissions change. Seal was failing silently.

## Change

Make Seal fail loudly